### PR TITLE
Allow for checking matching criteria in required slots 

### DIFF
--- a/components/home-content.tsx
+++ b/components/home-content.tsx
@@ -6,7 +6,8 @@ import { InlineLink } from '@/components/ui/link';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { WalletConnect } from '@/components/wallet-connect';
 import { paths } from '@/lib/paths';
-import type { OtomItem } from '@/lib/types';
+import { checkCriteria, isExactMatchCriteria } from '@/lib/property-utils';
+import type { BlueprintComponent, OtomItem } from '@/lib/types';
 import { DndContext, DragOverlay, type DragEndEvent, type DragStartEvent } from '@dnd-kit/core';
 import { ExternalLinkIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
@@ -70,13 +71,28 @@ export const HomeContent = () => {
           type: string;
           requiredTokenId?: string;
           index?: number;
+          component?: BlueprintComponent;
         };
         const draggedItemId = String(active.id);
 
         if (!droppedItemData || !dropZoneData) return;
 
         if (dropZoneData?.type === 'required') {
-          if (droppedItemData?.tokenId === dropZoneData?.requiredTokenId) {
+          const isVariableWithExactMatch =
+            dropZoneData.component?.componentType === 'variable_otom' &&
+            isExactMatchCriteria(dropZoneData.component.criteria || []);
+
+          let canDrop = false;
+
+          if (isVariableWithExactMatch && dropZoneData.component) {
+            // For variable with exact match, use checkCriteria
+            canDrop = checkCriteria(droppedItemData, dropZoneData.component.criteria);
+          } else {
+            // For standard required component, check token ID
+            canDrop = droppedItemData?.tokenId === dropZoneData?.requiredTokenId;
+          }
+
+          if (canDrop) {
             setDroppedOnRequiredSlots((prev) => new Set(prev).add(dropZoneId));
             setRequiredSlotToOtomMap((prev) => ({ ...prev, [dropZoneId]: draggedItemId }));
           }

--- a/components/home-content.tsx
+++ b/components/home-content.tsx
@@ -85,10 +85,8 @@ export const HomeContent = () => {
           let canDrop = false;
 
           if (isVariableWithExactMatch && dropZoneData.component) {
-            // For variable with exact match, use checkCriteria
             canDrop = checkCriteria(droppedItemData, dropZoneData.component.criteria);
           } else {
-            // For standard required component, check token ID
             canDrop = droppedItemData?.tokenId === dropZoneData?.requiredTokenId;
           }
 

--- a/lib/property-utils.ts
+++ b/lib/property-utils.ts
@@ -195,3 +195,16 @@ export function checkCriteria(item: OtomItem, criteria: BlueprintComponent['crit
   // If the loop completes without returning false, all criteria passed
   return true;
 }
+
+export function isExactMatchCriteria(criteria: BlueprintComponent['criteria']): boolean {
+  if (!criteria || criteria.length === 0) return false;
+
+  // Check if any criteria is an exact match rather than a range check
+  return criteria.some((c) => {
+    if (c.checkStringValue || c.checkBoolValue || (!c.minValue && !c.maxValue)) {
+      return true;
+    }
+
+    return false;
+  });
+}


### PR DESCRIPTION
currently required slots only check for a matching token id between blueprint component and the inventory item, which can cause issues when the blueprint element required can have several variations. for eg the `Ju3` required can have several token ids (depending on how it was reacted) so just checking token ids can prevent some variation of the molecule to be used to craft.

this pr extends required slots to also check `variable_otom` criteria such as the property `name`, which will make any matching `Ju3` molecule compatible.