### PR TITLE
Fix Typo in Error Name: "MissmatchItemType" to "MismatchItemType"

### DIFF
--- a/apps/web/abi/AssemblyCore.json
+++ b/apps/web/abi/AssemblyCore.json
@@ -60,7 +60,7 @@
       "type": "error"
     },
     { "inputs": [], "name": "MissingItemId", "type": "error" },
-    { "inputs": [], "name": "MissmatchItemType", "type": "error" },
+    { "inputs": [], "name": "MismatchItemType", "type": "error" },
     { "inputs": [], "name": "MutatorBlockedTransfer", "type": "error" },
     { "inputs": [], "name": "MutatorFailed", "type": "error" },
     { "inputs": [], "name": "NotAdmin", "type": "error" },

--- a/apps/web/generated.ts
+++ b/apps/web/generated.ts
@@ -70,7 +70,7 @@ export const assemblyCoreContractAbi = [
     name: 'ItemIsFrozen',
   },
   { type: 'error', inputs: [], name: 'MissingItemId' },
-  { type: 'error', inputs: [], name: 'MissmatchItemType' },
+  { type: 'error', inputs: [], name: 'MismatchItemType' },
   { type: 'error', inputs: [], name: 'MutatorBlockedTransfer' },
   { type: 'error', inputs: [], name: 'MutatorFailed' },
   { type: 'error', inputs: [], name: 'NotAdmin' },

--- a/packages/contracts/contracts/interfaces/IOtomItemsCore.sol
+++ b/packages/contracts/contracts/interfaces/IOtomItemsCore.sol
@@ -155,7 +155,7 @@ interface IOtomItemsCore {
     error InvalidTier(uint256 tier);
     error MutatorBlockedTransfer();
     error MissingItemId();
-    error MissmatchItemType();
+    error MismatchItemType();
     error CraftBlocked();
     error ItemAlreadyFrozen();
     error InvalidTraitType();

--- a/packages/contracts/contracts/items/OtomItemsCore.sol
+++ b/packages/contracts/contracts/items/OtomItemsCore.sol
@@ -1080,7 +1080,7 @@ contract OtomItemsCore is
                 Item storage item = _items[itemId];
 
                 // Ensure this is a non-fungible item
-                if (item.itemType != ItemType.NON_FUNGIBLE) revert MissmatchItemType();
+                if (item.itemType != ItemType.NON_FUNGIBLE) revert MismatchItemType();
 
                 // Get current traits to pass to the mutator
                 Trait[] memory currentTraits = getTokenTraits(_tokenId);


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the error name from "MissmatchItemType" to "MismatchItemType" in both the `AssemblyCore.json` ABI and the generated TypeScript contract ABI. This change ensures consistency and accuracy in error naming across the codebase. No other logic or functionality has been modified.
