### PR TITLE
feat: add floating window for otom inventory

### DIFF
--- a/apps/web/components/home-content.tsx
+++ b/apps/web/components/home-content.tsx
@@ -203,23 +203,18 @@ export const HomeContent = () => {
 
             {address ? (
               <div className="flex w-full flex-col gap-2">
-                {/* <div className="flex h-full w-full flex-col gap-2 overflow-hidden p-4"> */}
                 {isFloating ? (
                   <div className="pointer-events-none fixed inset-0 z-50 overflow-hidden">
                     <Rnd
                       position={rndPosition}
                       size={rndSize}
                       onDragStop={(e, d) => {
-                        // Save position to persisted state
                         setRndPosition({ x: d.x, y: d.y });
                       }}
                       onResize={(e, direction, ref, delta, position) => {
-                        // Update position during resize without saving to storage
-                        // This prevents excessive writes to localStorage
                         setRndPosition(position);
                       }}
                       onResizeStop={(e, direction, ref, delta, position) => {
-                        // Save final size and position to persisted state
                         setRndSize({
                           width: parseInt(ref.style.width),
                           height: parseInt(ref.style.height),

--- a/apps/web/components/home-content.tsx
+++ b/apps/web/components/home-content.tsx
@@ -8,9 +8,10 @@ import { WalletConnect } from '@/components/wallet-connect';
 import { paths } from '@/lib/paths';
 import { checkCriteria } from '@/lib/property-utils';
 import type { BlueprintComponent, OtomItem } from '@/lib/types';
+import { cn } from '@/lib/utils';
 import { DndContext, DragOverlay, type DragEndEvent, type DragStartEvent } from '@dnd-kit/core';
 import { Cross2Icon } from '@radix-ui/react-icons';
-import { useAtom } from 'jotai';
+import { useAtom } from 'jotai/react';
 import { atomWithStorage } from 'jotai/utils';
 import { AppWindow } from 'lucide-react';
 import Link from 'next/link';
@@ -115,44 +116,44 @@ export const HomeContent = () => {
     }));
   }, []);
 
-  const renderOtomsInventory = (isFloatingView = false) => (
-    <div
-      className={
-        isFloatingView
-          ? 'flex h-full w-full flex-col gap-2 overflow-hidden p-4'
-          : 'flex flex-col gap-2'
-      }
-    >
-      <div
-        className={`flex items-baseline justify-between gap-2 ${isFloatingView ? 'rnd-drag-handle cursor-move' : ''}`}
-      >
-        <h2 className="text-primary font-bold tracking-wide uppercase">Owned Otom Elements</h2>
-        <div className="flex items-center gap-2">
-          {!isFloating ? (
-            <button
-              onClick={handleOpenFloating}
-              className="text-muted-foreground/50 flex cursor-pointer items-center justify-center gap-2 text-sm no-underline hover:underline"
-              aria-label="Open window"
-            >
-              open in a window
-              <AppWindow className="size-4" />
-            </button>
-          ) : (
-            <button
-              onClick={() => setIsFloating(false)}
-              className="text-muted-foreground/70 hover:text-primary hover:bg-muted/50 flex h-6 w-6 cursor-pointer items-center justify-center rounded-full"
-              aria-label="Close window"
-            >
-              <Cross2Icon className="size-4" />
-            </button>
+  const renderOtomsInventory = useMemo(
+    () => (
+      <div className={cn('flex flex-col gap-2', isFloating && 'h-full w-full overflow-hidden p-4')}>
+        <div
+          className={cn(
+            'flex items-baseline justify-between gap-2',
+            isFloating && 'rnd-drag-handle cursor-move'
           )}
+        >
+          <h2 className="text-primary font-bold tracking-wide uppercase">Owned Otom Elements</h2>
+          <div className="flex items-center gap-2">
+            {!isFloating ? (
+              <button
+                onClick={handleOpenFloating}
+                className="text-muted-foreground/50 flex cursor-pointer items-center justify-center gap-2 text-sm no-underline hover:underline"
+                aria-label="Open window"
+              >
+                open in a window
+                <AppWindow className="size-4" />
+              </button>
+            ) : (
+              <button
+                onClick={() => setIsFloating(false)}
+                className="text-muted-foreground/70 hover:text-primary hover:bg-muted/50 flex h-6 w-6 cursor-pointer items-center justify-center rounded-full"
+                aria-label="Close window"
+              >
+                <Cross2Icon className="size-4" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className={cn('flex-1 overflow-auto', isFloating && 'h-full w-full')}>
+          <OtomsInventory usedCounts={usedCounts} />
         </div>
       </div>
-
-      <div className={isFloatingView ? 'flex-1 overflow-auto' : ''}>
-        <OtomsInventory usedCounts={usedCounts} />
-      </div>
-    </div>
+    ),
+    [isFloating, usedCounts]
   );
 
   return (
@@ -224,11 +225,11 @@ export const HomeContent = () => {
                       className="bg-background border-border pointer-events-auto rounded-lg border shadow-lg"
                       dragHandleClassName="rnd-drag-handle"
                     >
-                      {renderOtomsInventory(true)}
+                      {renderOtomsInventory}
                     </Rnd>
                   </div>
                 ) : (
-                  renderOtomsInventory(false)
+                  renderOtomsInventory
                 )}
 
                 <div className="mt-4 flex flex-wrap gap-2">

--- a/apps/web/components/inventories.tsx
+++ b/apps/web/components/inventories.tsx
@@ -14,8 +14,10 @@ import { isOtomAtom } from '@/lib/otoms';
 import { paths } from '@/lib/paths';
 import type { OtomItem } from '@/lib/types';
 import { cn } from '@/lib/utils';
+import { ExternalLinkIcon } from '@radix-ui/react-icons';
 import { useDeferredValue, useEffect, useMemo, useState, type FC } from 'react';
 import { useInView } from 'react-intersection-observer';
+import { InlineLink } from './ui/link';
 
 type GroupedOtomItems = {
   representativeItem: OtomItem;
@@ -138,7 +140,16 @@ export const OtomsInventory: FC<{ usedCounts: Map<string, number> }> = ({ usedCo
 
         {otomsAmount > 0 && (
           <div className="mt-4 flex flex-col gap-2">
-            <h3 className="text-muted-foreground text-sm">Otoms ({otomsAmount})</h3>
+            <div className="flex items-center justify-between gap-2">
+              <h3 className="text-muted-foreground text-sm">Otoms ({otomsAmount})</h3>
+
+              <InlineLink
+                href={paths.otom}
+                className="text-muted-foreground/50 text-sm no-underline hover:underline"
+              >
+                Mine more otoms <ExternalLinkIcon className="size-4" />
+              </InlineLink>
+            </div>
             <ul className="grid grid-cols-[repeat(auto-fill,minmax(64px,1fr))] items-start gap-2 rounded sm:flex sm:flex-wrap">
               {inventory.otoms.map((group) => (
                 <OtomItemCard

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.4",
     "react-intersection-observer": "^9.16.0",
+    "react-rnd": "^10.5.2",
     "sonner": "^2.0.3",
     "superjson": "^2.2.2",
     "tailwind-merge": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4761,7 +4761,7 @@ clsx@2.1.1, clsx@^2.1.1:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
-clsx@^1.2.1:
+clsx@^1.1.1, clsx@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
@@ -8294,12 +8294,25 @@ raw-body@^2.4.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+re-resizable@6.11.2:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.11.2.tgz#2e8f7119ca3881d5b5aea0ffa014a80e5c1252b3"
+  integrity sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==
+
 react-dom@^19.0.0:
   version "19.1.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.1.0.tgz#133558deca37fa1d682708df8904b25186793623"
   integrity sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==
   dependencies:
     scheduler "^0.26.0"
+
+react-draggable@4.4.6:
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
+  integrity sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==
+  dependencies:
+    clsx "^1.1.1"
+    prop-types "^15.8.1"
 
 react-hook-form@^7.56.4:
   version "7.56.4"
@@ -8345,6 +8358,15 @@ react-remove-scroll@^2.6.3:
     tslib "^2.1.0"
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.3"
+
+react-rnd@^10.5.2:
+  version "10.5.2"
+  resolved "https://registry.yarnpkg.com/react-rnd/-/react-rnd-10.5.2.tgz#47a22c104fb640dae71f149e2c005c879de833bd"
+  integrity sha512-0Tm4x7k7pfHf2snewJA8x7Nwgt3LV+58MVEWOVsFjk51eYruFEa6Wy7BNdxt4/lH0wIRsu7Gm3KjSXY2w7YaNw==
+  dependencies:
+    re-resizable "6.11.2"
+    react-draggable "4.4.6"
+    tslib "2.6.2"
 
 react-style-singleton@^2.2.1, react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
   version "2.2.3"
@@ -9398,6 +9420,11 @@ tslib@1.14.1, tslib@^1.11.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tslib@2.7.0:
   version "2.7.0"


### PR DESCRIPTION
- move mine more otoms link
- add a link to open otoms inventory as a window
- save position, preference and window size on local storage to keep rendering in the same place
<img width="1327" alt="image" src="https://github.com/user-attachments/assets/1dd652da-c121-4519-8bce-db1e85c5cf1c" />
<img width="1302" alt="image" src="https://github.com/user-attachments/assets/dbe1b5b0-ba8f-4ecc-a79a-44b2e41e12aa" />
