### PR TITLE
Only trigger onboarding wizard when user connects wallet

### DIFF
--- a/apps/web/components/home-content.tsx
+++ b/apps/web/components/home-content.tsx
@@ -153,7 +153,7 @@ export const HomeContent = () => {
   return (
     <main className="mx-auto grid min-h-screen max-w-7xl gap-4 sm:p-5">
       <OnboardingWizard
-        open={!onboardingCompleted}
+        open={!!address && !onboardingCompleted}
         onOpenChange={(open) => setOnboardingCompleted(!open)}
       />
 


### PR DESCRIPTION
default opening onboarding alert for every new user landing on the homepage can be bad for seo and in general not a fan of sudden pop ups like this. first the user discovers the page and we show onboarding after connecting their wallet