### PR TITLE
Add redirect to docs page

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -10,6 +10,15 @@ const nextConfig: NextConfig = {
       { hostname: '*' }, // only way to render images from any domain
     ],
   },
+  redirects: async () => {
+    return [
+      {
+        source: '/docs',
+        destination: 'https://docs.shape.network/building-on-shape/onchain-compatible/assembly',
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
more convenient url to share to people for assembly docs: `assembly.otom.xyz/docs`