### PR TITLE
feat: add a way to select wildcards for mobile

### DIFF
--- a/apps/web/components/floating-inventory.tsx
+++ b/apps/web/components/floating-inventory.tsx
@@ -51,8 +51,8 @@ export const FloatingInventory = () => {
     const windowWidth = window.innerWidth;
     const windowHeight = window.innerHeight;
 
-    const newX = Math.min(Math.max(0, rndPosition.x), windowWidth - rndSize.width);
-    const newY = Math.min(Math.max(0, rndPosition.y), windowHeight - rndSize.height);
+    const newX = Math.min(Math.max(0, rndPosition.x), windowWidth - rndSize.width - 150);
+    const newY = Math.min(Math.max(0, rndPosition.y), windowHeight - rndSize.height - 100);
 
     if (newX !== rndPosition.x || newY !== rndPosition.y) {
       setRndPosition({ x: newX, y: newY });
@@ -101,11 +101,12 @@ export const FloatingInventory = () => {
   }, [ensureWindowInBounds]);
 
   useEffect(() => {
-    if (isConnected) {
+    if (isConnected && isFloating === null && !isMobile) {
       setIsFloating(true);
       handleOpeningPosition();
+      return;
     }
-  }, [isConnected, setIsFloating, handleOpeningPosition]);
+  }, [isConnected, setIsFloating, handleOpeningPosition, isMobile, isFloating]);
 
   useEffect(() => {
     if (isSelectingWildcardId && !isFloating) {
@@ -117,7 +118,7 @@ export const FloatingInventory = () => {
 
   if (isMobile) {
     return (
-      <Drawer open={isFloating} onOpenChange={handleOpenChange} direction="bottom">
+      <Drawer open={isFloating === true} onOpenChange={handleOpenChange} direction="bottom">
         <DrawerContent className="max-h-[80vh]">
           <DrawerHeader className="py-0 pb-4">
             <div className="flex items-center justify-between">

--- a/apps/web/components/floating-inventory.tsx
+++ b/apps/web/components/floating-inventory.tsx
@@ -145,7 +145,7 @@ export const FloatingInventory = () => {
               </DrawerDescription>
             )}
           </DrawerHeader>
-          <div className="h-full overflow-auto p-4 pt-0">
+          <div className="h-full overflow-y-auto p-4 pt-0 -webkit-overflow-scrolling-touch">
             <OtomsInventory usedCounts={usedCounts} />
           </div>
         </DrawerContent>

--- a/apps/web/components/floating-inventory.tsx
+++ b/apps/web/components/floating-inventory.tsx
@@ -118,7 +118,7 @@ export const FloatingInventory = () => {
 
   if (isMobile) {
     return (
-      <Drawer open={isFloating === true} onOpenChange={handleOpenChange} direction="bottom">
+      <Drawer open={!!isFloating} onOpenChange={handleOpenChange} direction="bottom">
         <DrawerContent className="max-h-[80vh]">
           <DrawerHeader className="py-0 pb-4">
             <div className="flex items-center justify-between">

--- a/apps/web/components/floating-inventory.tsx
+++ b/apps/web/components/floating-inventory.tsx
@@ -1,11 +1,21 @@
 'use client';
 
+import { useMediaQuery } from '@/components/hooks/useMediaQuery';
 import { OtomsInventory } from '@/components/inventories';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
 import {
   droppedItemsStateAtom,
   inventoryWindowFloatingAtom,
   inventoryWindowPositionAtom,
   inventoryWindowSizeAtom,
+  isSelectingWildcardIdAtom,
 } from '@/lib/atoms';
 import { cn } from '@/lib/utils';
 import { Cross2Icon } from '@radix-ui/react-icons';
@@ -14,10 +24,13 @@ import { usePostHog } from 'posthog-js/react';
 import { useCallback, useEffect, useMemo } from 'react';
 import { Rnd } from 'react-rnd';
 import { useAccount } from 'wagmi';
+import { ComponentCriteriaDescription } from './items';
 
 export const FloatingInventory = () => {
   const { isConnected } = useAccount();
   const [droppedItemsState] = useAtom(droppedItemsStateAtom);
+  const isMobile = useMediaQuery('sm');
+  const [isSelectingWildcardId, setIsSelectingWildcardId] = useAtom(isSelectingWildcardIdAtom);
 
   const usedCounts = useMemo(() => {
     const counts = new Map<string, number>();
@@ -56,6 +69,22 @@ export const FloatingInventory = () => {
     setRndPosition({ x: Math.max(0, xPos), y: Math.max(0, yPos) });
   }, [rndSize, setRndPosition]);
 
+  const handleCloseFloating = useCallback(() => {
+    setIsSelectingWildcardId(null);
+    setIsFloating(false);
+  }, [setIsFloating, setIsSelectingWildcardId]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        setIsFloating(false);
+      } else {
+        handleCloseFloating();
+      }
+    },
+    [handleCloseFloating, setIsFloating]
+  );
+
   useEffect(() => {
     if (isFloating) {
       handleOpeningPosition();
@@ -78,7 +107,50 @@ export const FloatingInventory = () => {
     }
   }, [isConnected, setIsFloating, handleOpeningPosition]);
 
+  useEffect(() => {
+    if (isSelectingWildcardId && !isFloating) {
+      setIsFloating(true);
+    }
+  }, [isSelectingWildcardId, isFloating, setIsFloating]);
+
   if (!isConnected) return null;
+
+  if (isMobile) {
+    return (
+      <Drawer open={isFloating} onOpenChange={handleOpenChange} direction="bottom">
+        <DrawerContent className="max-h-[80vh]">
+          <DrawerHeader className="py-0 pb-4">
+            <div className="flex items-center justify-between">
+              <DrawerTitle className="text-primary font-bold tracking-wide uppercase">
+                Your Inventory
+              </DrawerTitle>
+              <DrawerClose
+                className="text-muted-foreground/70 hover:text-primary hover:bg-muted/50 z-10 flex h-6 w-6 cursor-pointer items-center justify-center rounded-full"
+                onClick={handleCloseFloating}
+              >
+                <Cross2Icon className="size-4" />
+              </DrawerClose>
+            </div>
+            {isSelectingWildcardId && (
+              <DrawerDescription className="text-left text-sm" asChild>
+                <div>
+                  Select the component you want to use for this wildcard. It must match the
+                  following criterias:
+                  <ComponentCriteriaDescription
+                    className="text-primary grid grid-cols-2 gap-2 py-4 text-sm"
+                    criteria={isSelectingWildcardId.criteria}
+                  />
+                </div>
+              </DrawerDescription>
+            )}
+          </DrawerHeader>
+          <div className="h-full overflow-auto p-4 pt-0">
+            <OtomsInventory usedCounts={usedCounts} />
+          </div>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
 
   return (
     <div className="pointer-events-none fixed inset-0 z-50 overflow-hidden">
@@ -118,7 +190,7 @@ export const FloatingInventory = () => {
                 </div>
                 <div className="absolute top-3 right-3 z-10">
                   <button
-                    onClick={() => setIsFloating(false)}
+                    onClick={handleCloseFloating}
                     className="text-muted-foreground/70 hover:text-primary hover:bg-muted/50 z-10 flex h-6 w-6 cursor-pointer items-center justify-center rounded-full"
                     aria-label="Close window"
                   >

--- a/apps/web/components/hooks/useMediaQuery.ts
+++ b/apps/web/components/hooks/useMediaQuery.ts
@@ -1,0 +1,42 @@
+import { useLayoutEffect, useState } from 'react';
+
+const viewports = {
+  sm: '(max-width: 640px)',
+  md: '(min-width: 641px) and (max-width: 1023px)',
+  lg: '(min-width: 1024px) and (max-width: 1279px)',
+  xl: '(min-width: 1280px) and (max-width: 1649px)',
+  '2xl': '(min-width: 1650px)',
+  'ultra-wide': '(min-width: 2500px)',
+} as const;
+
+type Viewports = keyof typeof viewports;
+
+function getMatches(query: string): boolean {
+  if (typeof window !== 'undefined') {
+    return window.matchMedia(query).matches;
+  }
+  return false;
+}
+
+export function useMediaQuery(viewport: Viewports): boolean {
+  const query = viewports[viewport];
+
+  const [matches, setMatches] = useState(getMatches(query));
+
+  useLayoutEffect(() => {
+    function handleChange() {
+      setMatches(getMatches(query));
+    }
+
+    handleChange();
+
+    const matchMedia = window.matchMedia(query);
+    matchMedia.addEventListener('change', handleChange);
+
+    return () => {
+      matchMedia.removeEventListener('change', handleChange);
+    };
+  }, [query]);
+
+  return matches;
+}

--- a/apps/web/components/inventories.tsx
+++ b/apps/web/components/inventories.tsx
@@ -109,7 +109,7 @@ export const OtomsInventory: FC<{ usedCounts: Map<string, number> }> = ({ usedCo
 
       <ScrollArea className="relative h-full max-h-[50vh] flex-col sm:max-h-[36vh]">
         {!isCreatePage && (
-          <p className="text-muted-foreground mb-4 text-xs italic select-none">
+          <p className="text-muted-foreground mb-4 hidden text-xs italic select-none md:block">
             Drag components into the desired slot to craft an item.
           </p>
         )}

--- a/apps/web/components/items.tsx
+++ b/apps/web/components/items.tsx
@@ -334,7 +334,7 @@ export const OtomItemCard: FC<OtomItemCardProps> = ({ representativeItem, count,
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: representativeItem.tokenId,
     data: representativeItem,
-    disabled: areAllItemsUsed || !!isSelectingWildcardId,
+    disabled: areAllItemsUsed || !!isSelectingWildcardId || isMobile,
   });
 
   const style = {

--- a/apps/web/components/items.tsx
+++ b/apps/web/components/items.tsx
@@ -15,13 +15,26 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { otomItemsCoreContractAbi, useWriteOtomItemsCoreContractCraftItem } from '@/generated';
 import { otomItemsCore } from '@/lib/addresses';
-import { droppedItemsStateAtom, hoveredOtomItemAtom } from '@/lib/atoms';
+import {
+  droppedItemsStateAtom,
+  hoveredOtomItemAtom,
+  inventoryWindowFloatingAtom,
+  isSelectingWildcardIdAtom,
+} from '@/lib/atoms';
 import { config } from '@/lib/config';
 import { useCopyToClipboard } from '@/lib/hooks';
 import { isOtomAtom } from '@/lib/otoms';
 import { paths } from '@/lib/paths';
 import { checkCriteria, formatPropertyName, isExactMatchCriteria } from '@/lib/property-utils';
-import { BlueprintComponent, Item, Molecule, OtomItem, OwnedItem, Trait } from '@/lib/types';
+import {
+  BlueprintComponent,
+  Criteria,
+  Item,
+  Molecule,
+  OtomItem,
+  OwnedItem,
+  Trait,
+} from '@/lib/types';
 import { abbreviateHash, cn, isNotNullish, isSameAddress } from '@/lib/utils';
 import { useDndContext, useDraggable, useDroppable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
@@ -35,6 +48,7 @@ import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { decodeEventLog, formatEther, toEventSelector } from 'viem';
 import { useAccount, useSwitchChain, useWaitForTransactionReceipt } from 'wagmi';
+import { useMediaQuery } from './hooks/useMediaQuery';
 
 export const ItemsToCraft: FC = () => {
   const { data, isLoading, isError } = useGetCraftableItems();
@@ -308,6 +322,10 @@ export const OtomItemCard: FC<OtomItemCardProps> = ({ representativeItem, count,
   const { isCopied, copyToClipboard } = useCopyToClipboard();
   const { data: craftableItems } = useGetCraftableItems();
   const [hoveredState, setHoveredState] = useAtom(hoveredOtomItemAtom);
+  const [isSelectingWildcardId, setIsSelectingWildcardId] = useAtom(isSelectingWildcardIdAtom);
+  const setDroppedItemsState = useSetAtom(droppedItemsStateAtom);
+  const setIsFloating = useSetAtom(inventoryWindowFloatingAtom);
+  const isMobile = useMediaQuery('sm');
 
   const usedCount = usedCounts.get(representativeItem.tokenId) || 0;
   const availableCount = count - usedCount;
@@ -316,7 +334,7 @@ export const OtomItemCard: FC<OtomItemCardProps> = ({ representativeItem, count,
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: representativeItem.tokenId,
     data: representativeItem,
-    disabled: areAllItemsUsed,
+    disabled: areAllItemsUsed || !!isSelectingWildcardId,
   });
 
   const style = {
@@ -379,7 +397,7 @@ export const OtomItemCard: FC<OtomItemCardProps> = ({ representativeItem, count,
           className={cn(
             'relative cursor-pointer touch-none py-0 font-semibold transition-colors',
             areAllItemsUsed
-              ? 'bg-primary text-primary-foreground'
+              ? 'bg-primary !text-primary-foreground'
               : isRequiredInBlueprint
                 ? 'border-primary text-primary border-dashed'
                 : 'border-border text-muted-foreground font-normal',
@@ -387,10 +405,37 @@ export const OtomItemCard: FC<OtomItemCardProps> = ({ representativeItem, count,
             (hoveredState?.item?.tokenId === representativeItem.tokenId ||
               shouldHighlightFromBlueprintHover) &&
               !areAllItemsUsed &&
-              'bg-primary/15'
+              'bg-primary/15',
+            isSelectingWildcardId === null
+              ? ''
+              : checkCriteria(representativeItem, isSelectingWildcardId.criteria)
+                ? 'text-primary border-primary border-dashed'
+                : 'bg-primary/10 border-border !text-muted-foreground'
           )}
         >
-          <CardContent className="grid aspect-square w-full place-items-center px-0 sm:size-15">
+          <CardContent
+            className="grid aspect-square w-full place-items-center px-0 sm:size-15"
+            onClick={() => {
+              if (!isMobile) return;
+              if (
+                isSelectingWildcardId &&
+                checkCriteria(representativeItem, isSelectingWildcardId.criteria)
+              ) {
+                const parts = isSelectingWildcardId.posId.split('-');
+                const itemId = parts[1];
+                const index = parts[2];
+                setDroppedItemsState((prev) => ({
+                  ...prev,
+                  [itemId]: {
+                    ...prev[itemId],
+                    [index]: representativeItem,
+                  },
+                }));
+                setIsSelectingWildcardId(null);
+                setIsFloating(false);
+              }
+            }}
+          >
             <ElementName otom={representativeItem} />
             {availableCount > 1 && (
               <span className="text-muted-foreground bg-background absolute -top-2 -right-2 grid h-5 min-w-[20px] place-items-center rounded-full px-0.5 text-[10px] font-bold">
@@ -909,7 +954,7 @@ const RequiredDropZone: FC<{
           {isDropped && (
             <button
               type="button"
-              className="absolute inset-0 z-10 hidden cursor-pointer items-center justify-center bg-white/25 group-hover:flex"
+              className="absolute inset-0 z-10 cursor-pointer items-center justify-center bg-white/25 group-hover:flex md:hidden"
               onClick={handleRemove}
               title="Remove component"
             >
@@ -950,9 +995,37 @@ const WildcardDropZone: FC<{
     id: id,
     data: { index, type: 'variable', component },
   });
+  const setIsSelectingWildcardIdAtom = useSetAtom(isSelectingWildcardIdAtom);
+  const setDroppedItemsState = useSetAtom(droppedItemsStateAtom);
+  const posthog = usePostHog();
 
   const draggedItem = active?.data.current as OtomItem | undefined;
   const canDrop = active ? checkCriteria(draggedItem!, component.criteria) : false;
+
+  const isMobile = useMediaQuery('sm');
+
+  const handleClick = useCallback(() => {
+    if (!isMobile || droppedItem) return;
+
+    setIsSelectingWildcardIdAtom({ ...component, posId: id });
+  }, [isMobile, droppedItem, setIsSelectingWildcardIdAtom, component, id]);
+
+  const handleRemove = useCallback(() => {
+    const parts = id.split('-');
+    const itemId = parts[1];
+    setDroppedItemsState((prev) => ({
+      ...prev,
+      [itemId]: {
+        ...prev[itemId],
+        [index]: null,
+      } as Record<number, OtomItem>,
+    }));
+    posthog?.capture('click', {
+      event: 'remove_component',
+      itemId,
+      componentType: component.componentType,
+    });
+  }, [setDroppedItemsState, id, index, posthog, component]);
 
   return (
     <Tooltip delayDuration={0}>
@@ -968,7 +1041,22 @@ const WildcardDropZone: FC<{
               isOver && !canDrop && 'ring-destructive ring-2 ring-offset-2'
             )}
           >
-            <CardContent className="grid size-15 place-items-center px-0">
+            <CardContent
+              className="group relative grid size-15 place-items-center px-0"
+              onClick={handleClick}
+            >
+              {droppedItem !== null && (
+                <button
+                  type="button"
+                  className="absolute inset-0 z-10 cursor-pointer items-center justify-center bg-white/25 group-hover:flex md:hidden"
+                  onClick={handleRemove}
+                  title="Remove component"
+                >
+                  <span className="absolute top-1 right-1 rounded bg-white/90 p-[3px]">
+                    <TrashIcon className="text-primary size-4" />
+                  </span>
+                </button>
+              )}
               {droppedItem ? (
                 droppedItem.name
               ) : (
@@ -988,37 +1076,49 @@ const WildcardDropZone: FC<{
       </TooltipTrigger>
 
       <TooltipContent>
-        <div className="flex flex-col gap-1">
-          {component.criteria.map((c) => (
-            <span key={c.propertyType}>
-              <p className="font-semibold">{formatPropertyName(c.propertyType)}</p>
-              <p className="flex gap-1">
-                {c.checkBoolValue ? (
-                  `Required: ${c.boolValue}`
-                ) : c.checkStringValue ? (
-                  `Required: ${c.stringValue}`
-                ) : (
-                  <>
-                    Range:{' '}
-                    {typeof c.minValue === 'number' && c.minValue > 10000
-                      ? `${c.minValue.toExponential(2)}`
-                      : String(c.minValue)}{' '}
-                    -{' '}
-                    {typeof c.maxValue === 'number' && c.maxValue > 1000000000 ? (
-                      <span className="text-sm">∞</span>
-                    ) : typeof c.maxValue === 'number' && c.maxValue > 10000 ? (
-                      `${c.maxValue.toExponential(2)}`
-                    ) : (
-                      String(c.maxValue)
-                    )}
-                  </>
-                )}
-              </p>
-            </span>
-          ))}
-        </div>
+        <ComponentCriteriaDescription criteria={component.criteria} />
       </TooltipContent>
     </Tooltip>
+  );
+};
+
+export const ComponentCriteriaDescription = ({
+  criteria,
+  className,
+}: {
+  criteria: Criteria[];
+  className?: string;
+}) => {
+  return (
+    <div className={cn('flex flex-col gap-1', className)}>
+      {criteria.map((c) => (
+        <span key={c.propertyType}>
+          <p className="font-semibold">{formatPropertyName(c.propertyType)}</p>
+          <p className="flex gap-1">
+            {c.checkBoolValue ? (
+              `Required: ${c.boolValue}`
+            ) : c.checkStringValue ? (
+              `Required: ${c.stringValue}`
+            ) : (
+              <>
+                Range:{' '}
+                {typeof c.minValue === 'number' && c.minValue > 10000
+                  ? `${c.minValue.toExponential(2)}`
+                  : String(c.minValue)}{' '}
+                -{' '}
+                {typeof c.maxValue === 'number' && c.maxValue > 1000000000 ? (
+                  <span className="text-sm">∞</span>
+                ) : typeof c.maxValue === 'number' && c.maxValue > 10000 ? (
+                  `${c.maxValue.toExponential(2)}`
+                ) : (
+                  String(c.maxValue)
+                )}
+              </>
+            )}
+          </p>
+        </span>
+      ))}
+    </div>
   );
 };
 

--- a/apps/web/components/navbar.tsx
+++ b/apps/web/components/navbar.tsx
@@ -57,7 +57,7 @@ export const Navbar: FC<GameMenuProps> = ({ className }) => {
           <MenuButton
             icon={<BackpackIcon className="size-5" />}
             tooltip={isFloating ? 'Close Inventory' : 'Open Inventory'}
-            isActive={isFloating}
+            isActive={isFloating === true}
             onClick={toggleInventory}
           />
           {config.chain.testnet && (

--- a/apps/web/components/navbar.tsx
+++ b/apps/web/components/navbar.tsx
@@ -57,7 +57,7 @@ export const Navbar: FC<GameMenuProps> = ({ className }) => {
           <MenuButton
             icon={<BackpackIcon className="size-5" />}
             tooltip={isFloating ? 'Close Inventory' : 'Open Inventory'}
-            isActive={isFloating === true}
+            isActive={isFloating}
             onClick={toggleInventory}
           />
           {config.chain.testnet && (
@@ -91,10 +91,10 @@ interface MenuButtonProps {
   icon: React.ReactNode;
   tooltip: string;
   onClick?: () => void;
-  isActive?: boolean;
+  isActive?: null | boolean;
 }
 
-const MenuButton: FC<MenuButtonProps> = ({ icon, tooltip, onClick, isActive = false }) => {
+const MenuButton: FC<MenuButtonProps> = ({ icon, tooltip, onClick, isActive = null }) => {
   return (
     <Tooltip>
       <TooltipTrigger asChild>

--- a/apps/web/components/ui/drawer.tsx
+++ b/apps/web/components/ui/drawer.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import * as React from 'react';
+import { Drawer as DrawerPrimitive } from 'vaul';
+
+import { cn } from '@/lib/utils';
+
+function Drawer({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
+          'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b',
+          'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t',
+          'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm',
+          'data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm',
+          className
+        )}
+        {...props}
+      >
+        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        'flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn('text-foreground font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+};

--- a/apps/web/lib/atoms.ts
+++ b/apps/web/lib/atoms.ts
@@ -9,17 +9,26 @@ export const hoveredOtomItemAtom = atom<{
 
 export const itemCreationBannerDismissedAtom = atom(false);
 
-export const inventoryWindowPositionAtom = atom<{ x: number; y: number }>({
-  x: 0,
-  y: 0,
-});
+export const inventoryWindowPositionAtom = atomWithStorage<{ x: number; y: number }>(
+  'inventory-position',
+  {
+    x: 0,
+    y: 0,
+  }
+);
 
-export const inventoryWindowSizeAtom = atom<{ width: number; height: number }>({
-  width: 410, // 5 columns of elements
-  height: 400,
-});
+export const inventoryWindowSizeAtom = atomWithStorage<{ width: number; height: number }>(
+  'inventory-size',
+  {
+    width: 410, // 5 columns of elements
+    height: 400,
+  }
+);
 
-export const inventoryWindowFloatingAtom = atom<boolean>(false);
+export const inventoryWindowFloatingAtom = atomWithStorage<boolean | null>(
+  'inventory-floating',
+  null
+);
 
 export const droppedItemsStateAtom = atom<Record<string, Record<number, OtomItem>>>({});
 

--- a/apps/web/lib/atoms.ts
+++ b/apps/web/lib/atoms.ts
@@ -24,3 +24,7 @@ export const inventoryWindowFloatingAtom = atom<boolean>(false);
 export const droppedItemsStateAtom = atom<Record<string, Record<number, OtomItem>>>({});
 
 export const onboardingCompletedAtom = atomWithStorage<boolean>('onboarding-completed', false);
+
+export const isSelectingWildcardIdAtom = atom<null | (BlueprintComponent & { posId: string })>(
+  null
+);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,6 +44,7 @@
     "superjson": "^2.2.2",
     "tailwind-merge": "^3.2.0",
     "tw-animate-css": "^1.2.5",
+    "vaul": "^1.1.2",
     "viem": "2.x",
     "wagmi": "^2.14.16",
     "zod": "^3.25.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,7 +2111,7 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.2.tgz#61628ef269a433382c364f6f1e3788a6dc213a36"
   integrity sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==
 
-"@radix-ui/react-dialog@1.1.14":
+"@radix-ui/react-dialog@1.1.14", "@radix-ui/react-dialog@^1.1.1":
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz#4c69c80c258bc6561398cfce055202ea11075107"
   integrity sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==
@@ -9908,6 +9908,13 @@ valtio@1.11.2:
   dependencies:
     proxy-compare "2.5.1"
     use-sync-external-store "1.2.0"
+
+vaul@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vaul/-/vaul-1.1.2.tgz#c959f8b9dc2ed4f7d99366caee433fbef91f5ba9"
+  integrity sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==
+  dependencies:
+    "@radix-ui/react-dialog" "^1.1.1"
 
 viem@2.23.2:
   version "2.23.2"


### PR DESCRIPTION
- persist inventory size, and opening status using atomWithStorage
- mobile:
  - drawer instead rnd component
  - clicks on wildcard component -> open the drawer -> user can see requirements and can select a component
  - new style for selectable components when using drawer inventory
  - fix remove component state as mobile doesn't have hover. Now, remove component state is show by default
- fix inventory position when resizing the window

![image](https://github.com/user-attachments/assets/1e5354bb-1ccd-41e8-905c-94769711a0b0)
![image](https://github.com/user-attachments/assets/c650b181-45af-4016-a340-84b48d0bfea5)
![image](https://github.com/user-attachments/assets/834dbd19-fd32-4ebc-9f0f-768f27be724c)
