### PR TITLE
upgrade: add `getItemImage` to `IOtomItemMutator`

### DIFF
--- a/apps/web/abi/OtomItemsCore.json
+++ b/apps/web/abi/OtomItemsCore.json
@@ -1,823 +1,835 @@
-[
-  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
-  { "inputs": [], "name": "CreationDisabled", "type": "error" },
-  { "inputs": [], "name": "CriteriaNotMet", "type": "error" },
-  { "inputs": [], "name": "InsufficientItemBalance", "type": "error" },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
-      { "internalType": "uint256", "name": "currentTier", "type": "uint256" },
-      { "internalType": "uint256", "name": "requiredTier", "type": "uint256" }
-    ],
-    "name": "InsufficientItemTier",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "required", "type": "uint256" },
-      { "internalType": "uint256", "name": "available", "type": "uint256" }
-    ],
-    "name": "InsufficientMatchingItems",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "required", "type": "uint256" },
-      { "internalType": "uint256", "name": "available", "type": "uint256" }
-    ],
-    "name": "InsufficientMatchingOtoms",
-    "type": "error"
-  },
-  { "inputs": [], "name": "InsufficientOtomBalance", "type": "error" },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "required", "type": "uint256" },
-      { "internalType": "uint256", "name": "provided", "type": "uint256" }
-    ],
-    "name": "InsufficientPayment",
-    "type": "error"
-  },
-  { "inputs": [], "name": "InvalidBlueprintComponent", "type": "error" },
-  { "inputs": [], "name": "InvalidCraftAmount", "type": "error" },
-  { "inputs": [], "name": "InvalidFeeRecipient", "type": "error" },
-  { "inputs": [], "name": "InvalidInitialization", "type": "error" },
-  { "inputs": [], "name": "InvalidItem", "type": "error" },
-  { "inputs": [], "name": "InvalidName", "type": "error" },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "tier", "type": "uint256" }],
-    "name": "InvalidTier",
-    "type": "error"
-  },
-  { "inputs": [], "name": "InvalidTraits", "type": "error" },
-  { "inputs": [], "name": "ItemAlreadyFrozen", "type": "error" },
-  { "inputs": [], "name": "ItemDoesNotExist", "type": "error" },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "itemId", "type": "uint256" }],
-    "name": "ItemIsFrozen",
-    "type": "error"
-  },
-  { "inputs": [], "name": "MissingItemId", "type": "error" },
-  { "inputs": [], "name": "MutatorBlocked", "type": "error" },
-  { "inputs": [], "name": "MutatorFailed", "type": "error" },
-  { "inputs": [], "name": "NotAdmin", "type": "error" },
-  { "inputs": [], "name": "NotInitializing", "type": "error" },
-  { "inputs": [], "name": "NotOtomItems", "type": "error" },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "msgSender", "type": "address" },
-      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
-    ],
-    "name": "NotOwner",
-    "type": "error"
-  },
-  { "inputs": [], "name": "OnlyFungible", "type": "error" },
-  { "inputs": [], "name": "OnlyNonFungible", "type": "error" },
-  {
-    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
-    "name": "OwnableInvalidOwner",
-    "type": "error"
-  },
-  {
-    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
-    "name": "OwnableUnauthorizedAccount",
-    "type": "error"
-  },
-  { "inputs": [], "name": "PaymentFailed", "type": "error" },
-  { "inputs": [], "name": "ReentrancyGuardReentrantCall", "type": "error" },
-  { "inputs": [], "name": "TraitNotFound", "type": "error" },
-  {
-    "anonymous": false,
-    "inputs": [{ "indexed": true, "internalType": "bool", "name": "isEnabled", "type": "bool" }],
-    "name": "CreationEnabledSet",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [{ "indexed": false, "internalType": "uint64", "name": "version", "type": "uint64" }],
-    "name": "Initialized",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "crafter", "type": "address" },
-      { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
-      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" },
-      { "indexed": false, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
-      {
-        "components": [
-          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-          { "internalType": "uint256", "name": "amount", "type": "uint256" },
-          {
-            "components": [
-              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-              { "internalType": "bool", "name": "boolValue", "type": "bool" },
-              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-              { "internalType": "string", "name": "stringValue", "type": "string" },
-              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-            ],
-            "internalType": "struct PropertyCriterion[]",
-            "name": "criteria",
-            "type": "tuple[]"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct ActualBlueprintComponent[]",
-        "name": "actualComponents",
-        "type": "tuple[]"
-      }
-    ],
-    "name": "ItemCrafted",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "creator", "type": "address" },
-      { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
-      { "indexed": false, "internalType": "string", "name": "name", "type": "string" }
-    ],
-    "name": "ItemCreated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
-      { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
-      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" }
-    ],
-    "name": "ItemDestroyed",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [{ "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" }],
-    "name": "ItemFrozen",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [{ "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" }],
-    "name": "ItemUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
-      { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
-      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" }
-    ],
-    "name": "ItemUsed",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
-      { "indexed": true, "internalType": "uint256[]", "name": "itemIds", "type": "uint256[]" },
-      { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
-      { "indexed": false, "internalType": "bool", "name": "approved", "type": "bool" }
-    ],
-    "name": "ItemsApprovalForAll",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "otomItems", "type": "address" }
-    ],
-    "name": "OtomItemsSet",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
-    ],
-    "name": "OwnershipTransferred",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "renderer", "type": "address" }
-    ],
-    "name": "RendererSet",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
-      { "indexed": true, "internalType": "uint256[]", "name": "tokenIds", "type": "uint256[]" },
-      { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
-      { "indexed": false, "internalType": "bool", "name": "approved", "type": "bool" }
-    ],
-    "name": "TokensApprovalForAll",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
-      {
-        "components": [
-          { "internalType": "string", "name": "typeName", "type": "string" },
-          { "internalType": "string", "name": "valueString", "type": "string" },
-          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-        ],
-        "indexed": false,
-        "internalType": "struct Trait[]",
-        "name": "traits",
-        "type": "tuple[]"
-      }
-    ],
-    "name": "TraitsUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "validator", "type": "address" }
-    ],
-    "name": "ValidatorSet",
-    "type": "event"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
-      { "internalType": "address", "name": "_owner", "type": "address" }
-    ],
-    "name": "consumeItem",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
-      { "internalType": "uint256[]", "name": "_variableOtomIds", "type": "uint256[]" },
-      { "internalType": "uint256[]", "name": "_nonFungibleTokenIds", "type": "uint256[]" },
-      { "internalType": "bytes", "name": "_data", "type": "bytes" }
-    ],
-    "name": "craftItem",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "string", "name": "_name", "type": "string" },
-      { "internalType": "string", "name": "_description", "type": "string" },
-      { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
-      {
-        "components": [
-          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-          { "internalType": "uint256", "name": "amount", "type": "uint256" },
-          {
-            "components": [
-              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-              { "internalType": "bool", "name": "boolValue", "type": "bool" },
-              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-              { "internalType": "string", "name": "stringValue", "type": "string" },
-              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-            ],
-            "internalType": "struct PropertyCriterion[]",
-            "name": "criteria",
-            "type": "tuple[]"
-          }
-        ],
-        "internalType": "struct BlueprintComponent[]",
-        "name": "_blueprint",
-        "type": "tuple[]"
-      },
-      {
-        "components": [
-          { "internalType": "string", "name": "typeName", "type": "string" },
-          { "internalType": "string", "name": "valueString", "type": "string" },
-          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-        ],
-        "internalType": "struct Trait[]",
-        "name": "_traits",
-        "type": "tuple[]"
-      },
-      { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
-      { "internalType": "address", "name": "_feeRecipient", "type": "address" },
-      { "internalType": "uint256", "name": "_defaultCraftAmount", "type": "uint256" }
-    ],
-    "name": "createFungibleItem",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "string", "name": "_name", "type": "string" },
-      { "internalType": "string", "name": "_description", "type": "string" },
-      { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
-      { "internalType": "string[7]", "name": "_defaultTierImageUris", "type": "string[7]" },
-      {
-        "components": [
-          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-          { "internalType": "uint256", "name": "amount", "type": "uint256" },
-          {
-            "components": [
-              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-              { "internalType": "bool", "name": "boolValue", "type": "bool" },
-              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-              { "internalType": "string", "name": "stringValue", "type": "string" },
-              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-            ],
-            "internalType": "struct PropertyCriterion[]",
-            "name": "criteria",
-            "type": "tuple[]"
-          }
-        ],
-        "internalType": "struct BlueprintComponent[]",
-        "name": "_blueprint",
-        "type": "tuple[]"
-      },
-      {
-        "components": [
-          { "internalType": "string", "name": "typeName", "type": "string" },
-          { "internalType": "string", "name": "valueString", "type": "string" },
-          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-        ],
-        "internalType": "struct Trait[]",
-        "name": "_traits",
-        "type": "tuple[]"
-      },
-      { "internalType": "address", "name": "_mutatorContract", "type": "address" },
-      { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
-      { "internalType": "address", "name": "_feeRecipient", "type": "address" }
-    ],
-    "name": "createNonFungibleItem",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "creationEnabled",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "_itemId", "type": "uint256" }],
-    "name": "freezeItem",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "name": "frozenItems",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "_itemId", "type": "uint256" }],
-    "name": "getItemByItemId",
-    "outputs": [
-      {
-        "components": [
-          { "internalType": "uint256", "name": "id", "type": "uint256" },
-          { "internalType": "string", "name": "name", "type": "string" },
-          { "internalType": "string", "name": "description", "type": "string" },
-          { "internalType": "address", "name": "creator", "type": "address" },
-          { "internalType": "address", "name": "admin", "type": "address" },
-          { "internalType": "string", "name": "defaultImageUri", "type": "string" },
-          { "internalType": "enum ItemType", "name": "itemType", "type": "uint8" },
-          {
-            "components": [
-              { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-              { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-              { "internalType": "uint256", "name": "amount", "type": "uint256" },
-              {
-                "components": [
-                  { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-                  { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-                  { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-                  { "internalType": "bool", "name": "boolValue", "type": "bool" },
-                  { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-                  { "internalType": "string", "name": "stringValue", "type": "string" },
-                  { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-                  { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-                  { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-                ],
-                "internalType": "struct PropertyCriterion[]",
-                "name": "criteria",
-                "type": "tuple[]"
-              }
-            ],
-            "internalType": "struct BlueprintComponent[]",
-            "name": "blueprint",
-            "type": "tuple[]"
-          },
-          { "internalType": "address", "name": "mutatorContract", "type": "address" },
-          { "internalType": "uint256", "name": "ethCostInWei", "type": "uint256" },
-          { "internalType": "address", "name": "feeRecipient", "type": "address" },
-          { "internalType": "string[7]", "name": "defaultTierImageUris", "type": "string[7]" },
-          { "internalType": "uint256", "name": "defaultCraftAmount", "type": "uint256" }
-        ],
-        "internalType": "struct Item",
-        "name": "",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
-    "name": "getItemIdForToken",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "itemId", "type": "uint256" },
-      { "internalType": "uint256", "name": "mintIndex", "type": "uint256" }
-    ],
-    "name": "getNonFungibleTokenId",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" },
-      { "internalType": "string", "name": "_traitName", "type": "string" }
-    ],
-    "name": "getTokenTrait",
-    "outputs": [
-      {
-        "components": [
-          { "internalType": "string", "name": "typeName", "type": "string" },
-          { "internalType": "string", "name": "valueString", "type": "string" },
-          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-        ],
-        "internalType": "struct Trait",
-        "name": "",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
-    "name": "getTokenTraits",
-    "outputs": [
-      {
-        "components": [
-          { "internalType": "string", "name": "typeName", "type": "string" },
-          { "internalType": "string", "name": "valueString", "type": "string" },
-          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-        ],
-        "internalType": "struct Trait[]",
-        "name": "",
-        "type": "tuple[]"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "tokenId", "type": "uint256" }],
-    "name": "getTokenUri",
-    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "_otomsAddress", "type": "address" },
-      { "internalType": "address", "name": "_otomsValidationAddress", "type": "address" }
-    ],
-    "name": "initialize",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "_owner", "type": "address" },
-      { "internalType": "address", "name": "_operator", "type": "address" },
-      { "internalType": "uint256", "name": "_itemId", "type": "uint256" }
-    ],
-    "name": "isApprovedForItem",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "_owner", "type": "address" },
-      { "internalType": "address", "name": "_operator", "type": "address" },
-      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
-    ],
-    "name": "isApprovedForToken",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
-    "name": "isFungibleTokenId",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "name": "itemMintCount",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "nextItemId",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
-    "name": "nonFungibleTokenToActualBlueprint",
-    "outputs": [
-      {
-        "components": [
-          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-          { "internalType": "uint256", "name": "amount", "type": "uint256" },
-          {
-            "components": [
-              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-              { "internalType": "bool", "name": "boolValue", "type": "bool" },
-              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-              { "internalType": "string", "name": "stringValue", "type": "string" },
-              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-            ],
-            "internalType": "struct PropertyCriterion[]",
-            "name": "criteria",
-            "type": "tuple[]"
-          }
-        ],
-        "internalType": "struct ActualBlueprintComponent[]",
-        "name": "",
-        "type": "tuple[]"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "name": "nonFungibleTokenToTier",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "_from", "type": "address" },
-      { "internalType": "address", "name": "_to", "type": "address" },
-      { "internalType": "uint256[]", "name": "_ids", "type": "uint256[]" },
-      { "internalType": "uint256[]", "name": "_values", "type": "uint256[]" }
-    ],
-    "name": "onUpdate",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "owner",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "renounceOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "_operator", "type": "address" },
-      { "internalType": "uint256[]", "name": "_itemIds", "type": "uint256[]" },
-      { "internalType": "bool", "name": "_approved", "type": "bool" }
-    ],
-    "name": "setApprovalForItemIds",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "_operator", "type": "address" },
-      { "internalType": "uint256[]", "name": "_tokenIds", "type": "uint256[]" },
-      { "internalType": "bool", "name": "_approved", "type": "bool" }
-    ],
-    "name": "setApprovalForTokenIds",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "bool", "name": "isEnabled", "type": "bool" }],
-    "name": "setCreationEnabled",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
-      { "internalType": "address", "name": "_admin", "type": "address" }
-    ],
-    "name": "setItemAdmin",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "address", "name": "_otomItemsAddress", "type": "address" }],
-    "name": "setOtomItems",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "address", "name": "_rendererAddress", "type": "address" }],
-    "name": "setRenderer",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "address", "name": "_validatorAddress", "type": "address" }],
-    "name": "setValidator",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
-    "name": "transferOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
-      { "internalType": "string", "name": "_name", "type": "string" },
-      { "internalType": "string", "name": "_description", "type": "string" },
-      {
-        "components": [
-          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-          { "internalType": "uint256", "name": "amount", "type": "uint256" },
-          {
-            "components": [
-              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-              { "internalType": "bool", "name": "boolValue", "type": "bool" },
-              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-              { "internalType": "string", "name": "stringValue", "type": "string" },
-              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-            ],
-            "internalType": "struct PropertyCriterion[]",
-            "name": "criteria",
-            "type": "tuple[]"
-          }
-        ],
-        "internalType": "struct BlueprintComponent[]",
-        "name": "_blueprint",
-        "type": "tuple[]"
-      },
-      {
-        "components": [
-          { "internalType": "string", "name": "typeName", "type": "string" },
-          { "internalType": "string", "name": "valueString", "type": "string" },
-          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-        ],
-        "internalType": "struct Trait[]",
-        "name": "_traits",
-        "type": "tuple[]"
-      },
-      { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
-      { "internalType": "address", "name": "_feeRecipient", "type": "address" },
-      { "internalType": "uint256", "name": "_defaultCraftAmount", "type": "uint256" }
-    ],
-    "name": "updateFungibleItem",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
-      { "internalType": "string", "name": "_name", "type": "string" },
-      { "internalType": "string", "name": "_description", "type": "string" },
-      { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
-      { "internalType": "string[7]", "name": "_defaultTierImageUris", "type": "string[7]" },
-      {
-        "components": [
-          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-          { "internalType": "uint256", "name": "amount", "type": "uint256" },
-          {
-            "components": [
-              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-              { "internalType": "bool", "name": "boolValue", "type": "bool" },
-              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-              { "internalType": "string", "name": "stringValue", "type": "string" },
-              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-            ],
-            "internalType": "struct PropertyCriterion[]",
-            "name": "criteria",
-            "type": "tuple[]"
-          }
-        ],
-        "internalType": "struct BlueprintComponent[]",
-        "name": "_blueprint",
-        "type": "tuple[]"
-      },
-      {
-        "components": [
-          { "internalType": "string", "name": "typeName", "type": "string" },
-          { "internalType": "string", "name": "valueString", "type": "string" },
-          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-        ],
-        "internalType": "struct Trait[]",
-        "name": "_traits",
-        "type": "tuple[]"
-      },
-      { "internalType": "address", "name": "_mutatorContract", "type": "address" },
-      { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
-      { "internalType": "address", "name": "_feeRecipient", "type": "address" }
-    ],
-    "name": "updateNonFungibleItem",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" },
-      { "internalType": "address", "name": "_owner", "type": "address" },
-      { "internalType": "bytes", "name": "_data", "type": "bytes" }
-    ],
-    "name": "useItem",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  }
-]
+{
+  "abi": [
+    { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+    { "inputs": [], "name": "CreationDisabled", "type": "error" },
+    { "inputs": [], "name": "CriteriaNotMet", "type": "error" },
+    { "inputs": [], "name": "InsufficientItemBalance", "type": "error" },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+        { "internalType": "uint256", "name": "currentTier", "type": "uint256" },
+        { "internalType": "uint256", "name": "requiredTier", "type": "uint256" }
+      ],
+      "name": "InsufficientItemTier",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "required", "type": "uint256" },
+        { "internalType": "uint256", "name": "available", "type": "uint256" }
+      ],
+      "name": "InsufficientMatchingItems",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "required", "type": "uint256" },
+        { "internalType": "uint256", "name": "available", "type": "uint256" }
+      ],
+      "name": "InsufficientMatchingOtoms",
+      "type": "error"
+    },
+    { "inputs": [], "name": "InsufficientOtomBalance", "type": "error" },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "required", "type": "uint256" },
+        { "internalType": "uint256", "name": "provided", "type": "uint256" }
+      ],
+      "name": "InsufficientPayment",
+      "type": "error"
+    },
+    { "inputs": [], "name": "InvalidBlueprintComponent", "type": "error" },
+    { "inputs": [], "name": "InvalidCraftAmount", "type": "error" },
+    { "inputs": [], "name": "InvalidFeeRecipient", "type": "error" },
+    { "inputs": [], "name": "InvalidInitialization", "type": "error" },
+    { "inputs": [], "name": "InvalidItem", "type": "error" },
+    { "inputs": [], "name": "InvalidName", "type": "error" },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "tier", "type": "uint256" }],
+      "name": "InvalidTier",
+      "type": "error"
+    },
+    { "inputs": [], "name": "InvalidTraits", "type": "error" },
+    { "inputs": [], "name": "ItemAlreadyFrozen", "type": "error" },
+    { "inputs": [], "name": "ItemDoesNotExist", "type": "error" },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "itemId", "type": "uint256" }],
+      "name": "ItemIsFrozen",
+      "type": "error"
+    },
+    { "inputs": [], "name": "MissingItemId", "type": "error" },
+    { "inputs": [], "name": "MutatorBlocked", "type": "error" },
+    { "inputs": [], "name": "MutatorFailed", "type": "error" },
+    { "inputs": [], "name": "NotAdmin", "type": "error" },
+    { "inputs": [], "name": "NotInitializing", "type": "error" },
+    { "inputs": [], "name": "NotOtomItems", "type": "error" },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "msgSender", "type": "address" },
+        { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+      ],
+      "name": "NotOwner",
+      "type": "error"
+    },
+    { "inputs": [], "name": "OnlyFungible", "type": "error" },
+    { "inputs": [], "name": "OnlyNonFungible", "type": "error" },
+    {
+      "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    { "inputs": [], "name": "PaymentFailed", "type": "error" },
+    { "inputs": [], "name": "ReentrancyGuardReentrantCall", "type": "error" },
+    { "inputs": [], "name": "TraitNotFound", "type": "error" },
+    {
+      "anonymous": false,
+      "inputs": [{ "indexed": true, "internalType": "bool", "name": "isEnabled", "type": "bool" }],
+      "name": "CreationEnabledSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": false, "internalType": "uint64", "name": "version", "type": "uint64" }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "crafter", "type": "address" },
+        { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
+        { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" },
+        { "indexed": false, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+        {
+          "components": [
+            { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+            { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+            { "internalType": "uint256", "name": "amount", "type": "uint256" },
+            {
+              "components": [
+                { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+                { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+                { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+                { "internalType": "bool", "name": "boolValue", "type": "bool" },
+                { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+                { "internalType": "string", "name": "stringValue", "type": "string" },
+                { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+                { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+                { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+              ],
+              "internalType": "struct PropertyCriterion[]",
+              "name": "criteria",
+              "type": "tuple[]"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct ActualBlueprintComponent[]",
+          "name": "actualComponents",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "ItemCrafted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "creator", "type": "address" },
+        { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
+        { "indexed": false, "internalType": "string", "name": "name", "type": "string" }
+      ],
+      "name": "ItemCreated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+        { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
+        { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+      ],
+      "name": "ItemDestroyed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" }
+      ],
+      "name": "ItemFrozen",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" }
+      ],
+      "name": "ItemUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+        { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
+        { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+      ],
+      "name": "ItemUsed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+        { "indexed": true, "internalType": "uint256[]", "name": "itemIds", "type": "uint256[]" },
+        { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
+        { "indexed": false, "internalType": "bool", "name": "approved", "type": "bool" }
+      ],
+      "name": "ItemsApprovalForAll",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "otomItems", "type": "address" }
+      ],
+      "name": "OtomItemsSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+        { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "renderer", "type": "address" }
+      ],
+      "name": "RendererSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+        { "indexed": true, "internalType": "uint256[]", "name": "tokenIds", "type": "uint256[]" },
+        { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
+        { "indexed": false, "internalType": "bool", "name": "approved", "type": "bool" }
+      ],
+      "name": "TokensApprovalForAll",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+        {
+          "components": [
+            { "internalType": "string", "name": "typeName", "type": "string" },
+            { "internalType": "string", "name": "valueString", "type": "string" },
+            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+          ],
+          "indexed": false,
+          "internalType": "struct Trait[]",
+          "name": "traits",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "TraitsUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "validator", "type": "address" }
+      ],
+      "name": "ValidatorSet",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
+        { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+        { "internalType": "address", "name": "_owner", "type": "address" }
+      ],
+      "name": "consumeItem",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
+        { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+        { "internalType": "uint256[]", "name": "_variableOtomIds", "type": "uint256[]" },
+        { "internalType": "uint256[]", "name": "_nonFungibleTokenIds", "type": "uint256[]" },
+        { "internalType": "bytes", "name": "_data", "type": "bytes" }
+      ],
+      "name": "craftItem",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "string", "name": "_name", "type": "string" },
+        { "internalType": "string", "name": "_description", "type": "string" },
+        { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
+        {
+          "components": [
+            { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+            { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+            { "internalType": "uint256", "name": "amount", "type": "uint256" },
+            {
+              "components": [
+                { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+                { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+                { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+                { "internalType": "bool", "name": "boolValue", "type": "bool" },
+                { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+                { "internalType": "string", "name": "stringValue", "type": "string" },
+                { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+                { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+                { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+              ],
+              "internalType": "struct PropertyCriterion[]",
+              "name": "criteria",
+              "type": "tuple[]"
+            }
+          ],
+          "internalType": "struct BlueprintComponent[]",
+          "name": "_blueprint",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            { "internalType": "string", "name": "typeName", "type": "string" },
+            { "internalType": "string", "name": "valueString", "type": "string" },
+            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+          ],
+          "internalType": "struct Trait[]",
+          "name": "_traits",
+          "type": "tuple[]"
+        },
+        { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
+        { "internalType": "address", "name": "_feeRecipient", "type": "address" },
+        { "internalType": "uint256", "name": "_defaultCraftAmount", "type": "uint256" }
+      ],
+      "name": "createFungibleItem",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "string", "name": "_name", "type": "string" },
+        { "internalType": "string", "name": "_description", "type": "string" },
+        { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
+        { "internalType": "string[7]", "name": "_defaultTierImageUris", "type": "string[7]" },
+        {
+          "components": [
+            { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+            { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+            { "internalType": "uint256", "name": "amount", "type": "uint256" },
+            {
+              "components": [
+                { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+                { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+                { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+                { "internalType": "bool", "name": "boolValue", "type": "bool" },
+                { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+                { "internalType": "string", "name": "stringValue", "type": "string" },
+                { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+                { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+                { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+              ],
+              "internalType": "struct PropertyCriterion[]",
+              "name": "criteria",
+              "type": "tuple[]"
+            }
+          ],
+          "internalType": "struct BlueprintComponent[]",
+          "name": "_blueprint",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            { "internalType": "string", "name": "typeName", "type": "string" },
+            { "internalType": "string", "name": "valueString", "type": "string" },
+            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+          ],
+          "internalType": "struct Trait[]",
+          "name": "_traits",
+          "type": "tuple[]"
+        },
+        { "internalType": "address", "name": "_mutatorContract", "type": "address" },
+        { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
+        { "internalType": "address", "name": "_feeRecipient", "type": "address" }
+      ],
+      "name": "createNonFungibleItem",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "creationEnabled",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "_itemId", "type": "uint256" }],
+      "name": "freezeItem",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "name": "frozenItems",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "_itemId", "type": "uint256" }],
+      "name": "getItemByItemId",
+      "outputs": [
+        {
+          "components": [
+            { "internalType": "uint256", "name": "id", "type": "uint256" },
+            { "internalType": "string", "name": "name", "type": "string" },
+            { "internalType": "string", "name": "description", "type": "string" },
+            { "internalType": "address", "name": "creator", "type": "address" },
+            { "internalType": "address", "name": "admin", "type": "address" },
+            { "internalType": "string", "name": "defaultImageUri", "type": "string" },
+            { "internalType": "enum ItemType", "name": "itemType", "type": "uint8" },
+            {
+              "components": [
+                { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+                { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+                { "internalType": "uint256", "name": "amount", "type": "uint256" },
+                {
+                  "components": [
+                    {
+                      "internalType": "enum PropertyType",
+                      "name": "propertyType",
+                      "type": "uint8"
+                    },
+                    { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+                    { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+                    { "internalType": "bool", "name": "boolValue", "type": "bool" },
+                    { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+                    { "internalType": "string", "name": "stringValue", "type": "string" },
+                    { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+                    { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+                    { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+                  ],
+                  "internalType": "struct PropertyCriterion[]",
+                  "name": "criteria",
+                  "type": "tuple[]"
+                }
+              ],
+              "internalType": "struct BlueprintComponent[]",
+              "name": "blueprint",
+              "type": "tuple[]"
+            },
+            { "internalType": "address", "name": "mutatorContract", "type": "address" },
+            { "internalType": "uint256", "name": "ethCostInWei", "type": "uint256" },
+            { "internalType": "address", "name": "feeRecipient", "type": "address" },
+            { "internalType": "string[7]", "name": "defaultTierImageUris", "type": "string[7]" },
+            { "internalType": "uint256", "name": "defaultCraftAmount", "type": "uint256" }
+          ],
+          "internalType": "struct Item",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
+      "name": "getItemIdForToken",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "itemId", "type": "uint256" },
+        { "internalType": "uint256", "name": "mintIndex", "type": "uint256" }
+      ],
+      "name": "getNonFungibleTokenId",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "_tokenId", "type": "uint256" },
+        { "internalType": "string", "name": "_traitName", "type": "string" }
+      ],
+      "name": "getTokenTrait",
+      "outputs": [
+        {
+          "components": [
+            { "internalType": "string", "name": "typeName", "type": "string" },
+            { "internalType": "string", "name": "valueString", "type": "string" },
+            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+          ],
+          "internalType": "struct Trait",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
+      "name": "getTokenTraits",
+      "outputs": [
+        {
+          "components": [
+            { "internalType": "string", "name": "typeName", "type": "string" },
+            { "internalType": "string", "name": "valueString", "type": "string" },
+            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+          ],
+          "internalType": "struct Trait[]",
+          "name": "",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "tokenId", "type": "uint256" }],
+      "name": "getTokenUri",
+      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_otomsAddress", "type": "address" },
+        { "internalType": "address", "name": "_otomsValidationAddress", "type": "address" }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_owner", "type": "address" },
+        { "internalType": "address", "name": "_operator", "type": "address" },
+        { "internalType": "uint256", "name": "_itemId", "type": "uint256" }
+      ],
+      "name": "isApprovedForItem",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_owner", "type": "address" },
+        { "internalType": "address", "name": "_operator", "type": "address" },
+        { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
+      ],
+      "name": "isApprovedForToken",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
+      "name": "isFungibleTokenId",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "name": "itemMintCount",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "nextItemId",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
+      "name": "nonFungibleTokenToActualBlueprint",
+      "outputs": [
+        {
+          "components": [
+            { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+            { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+            { "internalType": "uint256", "name": "amount", "type": "uint256" },
+            {
+              "components": [
+                { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+                { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+                { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+                { "internalType": "bool", "name": "boolValue", "type": "bool" },
+                { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+                { "internalType": "string", "name": "stringValue", "type": "string" },
+                { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+                { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+                { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+              ],
+              "internalType": "struct PropertyCriterion[]",
+              "name": "criteria",
+              "type": "tuple[]"
+            }
+          ],
+          "internalType": "struct ActualBlueprintComponent[]",
+          "name": "",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "name": "nonFungibleTokenToTier",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_from", "type": "address" },
+        { "internalType": "address", "name": "_to", "type": "address" },
+        { "internalType": "uint256[]", "name": "_ids", "type": "uint256[]" },
+        { "internalType": "uint256[]", "name": "_values", "type": "uint256[]" }
+      ],
+      "name": "onUpdate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_operator", "type": "address" },
+        { "internalType": "uint256[]", "name": "_itemIds", "type": "uint256[]" },
+        { "internalType": "bool", "name": "_approved", "type": "bool" }
+      ],
+      "name": "setApprovalForItemIds",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_operator", "type": "address" },
+        { "internalType": "uint256[]", "name": "_tokenIds", "type": "uint256[]" },
+        { "internalType": "bool", "name": "_approved", "type": "bool" }
+      ],
+      "name": "setApprovalForTokenIds",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "bool", "name": "isEnabled", "type": "bool" }],
+      "name": "setCreationEnabled",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
+        { "internalType": "address", "name": "_admin", "type": "address" }
+      ],
+      "name": "setItemAdmin",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "_otomItemsAddress", "type": "address" }],
+      "name": "setOtomItems",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "_rendererAddress", "type": "address" }],
+      "name": "setRenderer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "_validatorAddress", "type": "address" }],
+      "name": "setValidator",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
+        { "internalType": "string", "name": "_name", "type": "string" },
+        { "internalType": "string", "name": "_description", "type": "string" },
+        {
+          "components": [
+            { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+            { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+            { "internalType": "uint256", "name": "amount", "type": "uint256" },
+            {
+              "components": [
+                { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+                { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+                { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+                { "internalType": "bool", "name": "boolValue", "type": "bool" },
+                { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+                { "internalType": "string", "name": "stringValue", "type": "string" },
+                { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+                { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+                { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+              ],
+              "internalType": "struct PropertyCriterion[]",
+              "name": "criteria",
+              "type": "tuple[]"
+            }
+          ],
+          "internalType": "struct BlueprintComponent[]",
+          "name": "_blueprint",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            { "internalType": "string", "name": "typeName", "type": "string" },
+            { "internalType": "string", "name": "valueString", "type": "string" },
+            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+          ],
+          "internalType": "struct Trait[]",
+          "name": "_traits",
+          "type": "tuple[]"
+        },
+        { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
+        { "internalType": "address", "name": "_feeRecipient", "type": "address" },
+        { "internalType": "uint256", "name": "_defaultCraftAmount", "type": "uint256" }
+      ],
+      "name": "updateFungibleItem",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
+        { "internalType": "string", "name": "_name", "type": "string" },
+        { "internalType": "string", "name": "_description", "type": "string" },
+        { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
+        { "internalType": "string[7]", "name": "_defaultTierImageUris", "type": "string[7]" },
+        {
+          "components": [
+            { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+            { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+            { "internalType": "uint256", "name": "amount", "type": "uint256" },
+            {
+              "components": [
+                { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+                { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+                { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+                { "internalType": "bool", "name": "boolValue", "type": "bool" },
+                { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+                { "internalType": "string", "name": "stringValue", "type": "string" },
+                { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+                { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+                { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+              ],
+              "internalType": "struct PropertyCriterion[]",
+              "name": "criteria",
+              "type": "tuple[]"
+            }
+          ],
+          "internalType": "struct BlueprintComponent[]",
+          "name": "_blueprint",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            { "internalType": "string", "name": "typeName", "type": "string" },
+            { "internalType": "string", "name": "valueString", "type": "string" },
+            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+          ],
+          "internalType": "struct Trait[]",
+          "name": "_traits",
+          "type": "tuple[]"
+        },
+        { "internalType": "address", "name": "_mutatorContract", "type": "address" },
+        { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
+        { "internalType": "address", "name": "_feeRecipient", "type": "address" }
+      ],
+      "name": "updateNonFungibleItem",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "_tokenId", "type": "uint256" },
+        { "internalType": "address", "name": "_owner", "type": "address" },
+        { "internalType": "bytes", "name": "_data", "type": "bytes" }
+      ],
+      "name": "useItem",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/apps/web/abi/OtomItemsCore.json
+++ b/apps/web/abi/OtomItemsCore.json
@@ -1,842 +1,823 @@
-{
-  "abi": [
-    { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
-    { "inputs": [], "name": "CreationDisabled", "type": "error" },
-    { "inputs": [], "name": "CriteriaNotMet", "type": "error" },
-    { "inputs": [], "name": "InsufficientItemBalance", "type": "error" },
-    {
-      "inputs": [
-        { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
-        { "internalType": "uint256", "name": "currentTier", "type": "uint256" },
-        { "internalType": "uint256", "name": "requiredTier", "type": "uint256" }
-      ],
-      "name": "InsufficientItemTier",
-      "type": "error"
-    },
-    {
-      "inputs": [
-        { "internalType": "uint256", "name": "required", "type": "uint256" },
-        { "internalType": "uint256", "name": "available", "type": "uint256" }
-      ],
-      "name": "InsufficientMatchingItems",
-      "type": "error"
-    },
-    {
-      "inputs": [
-        { "internalType": "uint256", "name": "required", "type": "uint256" },
-        { "internalType": "uint256", "name": "available", "type": "uint256" }
-      ],
-      "name": "InsufficientMatchingOtoms",
-      "type": "error"
-    },
-    { "inputs": [], "name": "InsufficientOtomBalance", "type": "error" },
-    {
-      "inputs": [
-        { "internalType": "uint256", "name": "required", "type": "uint256" },
-        { "internalType": "uint256", "name": "provided", "type": "uint256" }
-      ],
-      "name": "InsufficientPayment",
-      "type": "error"
-    },
-    { "inputs": [], "name": "InvalidBlueprintComponent", "type": "error" },
-    { "inputs": [], "name": "InvalidCraftAmount", "type": "error" },
-    { "inputs": [], "name": "InvalidFeeRecipient", "type": "error" },
-    { "inputs": [], "name": "InvalidInitialization", "type": "error" },
-    { "inputs": [], "name": "InvalidItem", "type": "error" },
-    { "inputs": [], "name": "InvalidName", "type": "error" },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "tier", "type": "uint256" }],
-      "name": "InvalidTier",
-      "type": "error"
-    },
-    { "inputs": [], "name": "InvalidTraits", "type": "error" },
-    { "inputs": [], "name": "ItemAlreadyFrozen", "type": "error" },
-    { "inputs": [], "name": "ItemDoesNotExist", "type": "error" },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "itemId", "type": "uint256" }],
-      "name": "ItemIsFrozen",
-      "type": "error"
-    },
-    { "inputs": [], "name": "MissingItemId", "type": "error" },
-    { "inputs": [], "name": "MutatorBlocked", "type": "error" },
-    { "inputs": [], "name": "MutatorFailed", "type": "error" },
-    { "inputs": [], "name": "NotAdmin", "type": "error" },
-    { "inputs": [], "name": "NotInitializing", "type": "error" },
-    { "inputs": [], "name": "NotOtomItems", "type": "error" },
-    {
-      "inputs": [
-        { "internalType": "address", "name": "msgSender", "type": "address" },
-        { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
-      ],
-      "name": "NotOwner",
-      "type": "error"
-    },
-    { "inputs": [], "name": "OnlyFungible", "type": "error" },
-    { "inputs": [], "name": "OnlyNonFungible", "type": "error" },
-    {
-      "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
-      "name": "OwnableInvalidOwner",
-      "type": "error"
-    },
-    {
-      "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
-      "name": "OwnableUnauthorizedAccount",
-      "type": "error"
-    },
-    { "inputs": [], "name": "PaymentFailed", "type": "error" },
-    { "inputs": [], "name": "ReentrancyGuardReentrantCall", "type": "error" },
-    { "inputs": [], "name": "TraitNotFound", "type": "error" },
-    {
-      "anonymous": false,
-      "inputs": [{ "indexed": true, "internalType": "bool", "name": "isEnabled", "type": "bool" }],
-      "name": "CreationEnabledSet",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": false, "internalType": "uint64", "name": "version", "type": "uint64" }
-      ],
-      "name": "Initialized",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "address", "name": "crafter", "type": "address" },
-        { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
-        { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" },
-        { "indexed": false, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
-        {
-          "components": [
-            { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-            { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-            { "internalType": "uint256", "name": "amount", "type": "uint256" },
-            {
-              "components": [
-                { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-                { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-                { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-                { "internalType": "bool", "name": "boolValue", "type": "bool" },
-                { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-                { "internalType": "string", "name": "stringValue", "type": "string" },
-                { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-                { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-                { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-              ],
-              "internalType": "struct PropertyCriterion[]",
-              "name": "criteria",
-              "type": "tuple[]"
-            }
-          ],
-          "indexed": false,
-          "internalType": "struct ActualBlueprintComponent[]",
-          "name": "actualComponents",
-          "type": "tuple[]"
-        }
-      ],
-      "name": "ItemCrafted",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "address", "name": "creator", "type": "address" },
-        { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
-        { "indexed": false, "internalType": "string", "name": "name", "type": "string" }
-      ],
-      "name": "ItemCreated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
-        { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
-        { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" }
-      ],
-      "name": "ItemDestroyed",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" }
-      ],
-      "name": "ItemFrozen",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" }
-      ],
-      "name": "ItemUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
-        { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
-        { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" }
-      ],
-      "name": "ItemUsed",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
-        { "indexed": true, "internalType": "uint256[]", "name": "itemIds", "type": "uint256[]" },
-        { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
-        { "indexed": false, "internalType": "bool", "name": "approved", "type": "bool" }
-      ],
-      "name": "ItemsApprovalForAll",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "address", "name": "otomItems", "type": "address" }
-      ],
-      "name": "OtomItemsSet",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
-        { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
-      ],
-      "name": "OwnershipTransferred",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "address", "name": "renderer", "type": "address" }
-      ],
-      "name": "RendererSet",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
-        { "indexed": true, "internalType": "uint256[]", "name": "tokenIds", "type": "uint256[]" },
-        { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
-        { "indexed": false, "internalType": "bool", "name": "approved", "type": "bool" }
-      ],
-      "name": "TokensApprovalForAll",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
-        {
-          "components": [
-            { "internalType": "string", "name": "typeName", "type": "string" },
-            { "internalType": "string", "name": "valueString", "type": "string" },
-            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-          ],
-          "indexed": false,
-          "internalType": "struct Trait[]",
-          "name": "traits",
-          "type": "tuple[]"
-        }
-      ],
-      "name": "TraitsUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        { "indexed": true, "internalType": "address", "name": "validator", "type": "address" }
-      ],
-      "name": "ValidatorSet",
-      "type": "event"
-    },
-    {
-      "inputs": [
-        { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
-        { "internalType": "uint256", "name": "_amount", "type": "uint256" },
-        { "internalType": "address", "name": "_owner", "type": "address" }
-      ],
-      "name": "consumeItem",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
-        { "internalType": "uint256", "name": "_amount", "type": "uint256" },
-        { "internalType": "uint256[]", "name": "_variableOtomIds", "type": "uint256[]" },
-        { "internalType": "uint256[]", "name": "_nonFungibleTokenIds", "type": "uint256[]" },
-        { "internalType": "bytes", "name": "_data", "type": "bytes" }
-      ],
-      "name": "craftItem",
-      "outputs": [],
-      "stateMutability": "payable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "string", "name": "_name", "type": "string" },
-        { "internalType": "string", "name": "_description", "type": "string" },
-        { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
-        {
-          "components": [
-            { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-            { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-            { "internalType": "uint256", "name": "amount", "type": "uint256" },
-            {
-              "components": [
-                { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-                { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-                { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-                { "internalType": "bool", "name": "boolValue", "type": "bool" },
-                { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-                { "internalType": "string", "name": "stringValue", "type": "string" },
-                { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-                { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-                { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-              ],
-              "internalType": "struct PropertyCriterion[]",
-              "name": "criteria",
-              "type": "tuple[]"
-            }
-          ],
-          "internalType": "struct BlueprintComponent[]",
-          "name": "_blueprint",
-          "type": "tuple[]"
-        },
-        {
-          "components": [
-            { "internalType": "string", "name": "typeName", "type": "string" },
-            { "internalType": "string", "name": "valueString", "type": "string" },
-            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-          ],
-          "internalType": "struct Trait[]",
-          "name": "_traits",
-          "type": "tuple[]"
-        },
-        { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
-        { "internalType": "address", "name": "_feeRecipient", "type": "address" },
-        { "internalType": "uint256", "name": "_defaultCraftAmount", "type": "uint256" }
-      ],
-      "name": "createFungibleItem",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "string", "name": "_name", "type": "string" },
-        { "internalType": "string", "name": "_description", "type": "string" },
-        { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
-        { "internalType": "string[7]", "name": "_defaultTierImageUris", "type": "string[7]" },
-        {
-          "components": [
-            { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-            { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-            { "internalType": "uint256", "name": "amount", "type": "uint256" },
-            {
-              "components": [
-                { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-                { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-                { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-                { "internalType": "bool", "name": "boolValue", "type": "bool" },
-                { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-                { "internalType": "string", "name": "stringValue", "type": "string" },
-                { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-                { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-                { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-              ],
-              "internalType": "struct PropertyCriterion[]",
-              "name": "criteria",
-              "type": "tuple[]"
-            }
-          ],
-          "internalType": "struct BlueprintComponent[]",
-          "name": "_blueprint",
-          "type": "tuple[]"
-        },
-        {
-          "components": [
-            { "internalType": "string", "name": "typeName", "type": "string" },
-            { "internalType": "string", "name": "valueString", "type": "string" },
-            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-          ],
-          "internalType": "struct Trait[]",
-          "name": "_traits",
-          "type": "tuple[]"
-        },
-        { "internalType": "address", "name": "_mutatorContract", "type": "address" },
-        { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
-        { "internalType": "address", "name": "_feeRecipient", "type": "address" }
-      ],
-      "name": "createNonFungibleItem",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "creationEnabled",
-      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "_itemId", "type": "uint256" }],
-      "name": "freezeItem",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "name": "frozenItems",
-      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "_itemId", "type": "uint256" }],
-      "name": "getItemByItemId",
-      "outputs": [
-        {
-          "components": [
-            { "internalType": "uint256", "name": "id", "type": "uint256" },
-            { "internalType": "string", "name": "name", "type": "string" },
-            { "internalType": "string", "name": "description", "type": "string" },
-            { "internalType": "address", "name": "creator", "type": "address" },
-            { "internalType": "address", "name": "admin", "type": "address" },
-            { "internalType": "string", "name": "defaultImageUri", "type": "string" },
-            { "internalType": "enum ItemType", "name": "itemType", "type": "uint8" },
-            {
-              "components": [
-                { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-                { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-                { "internalType": "uint256", "name": "amount", "type": "uint256" },
-                {
-                  "components": [
-                    {
-                      "internalType": "enum PropertyType",
-                      "name": "propertyType",
-                      "type": "uint8"
-                    },
-                    { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-                    { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-                    { "internalType": "bool", "name": "boolValue", "type": "bool" },
-                    { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-                    { "internalType": "string", "name": "stringValue", "type": "string" },
-                    { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-                    { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-                    { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-                  ],
-                  "internalType": "struct PropertyCriterion[]",
-                  "name": "criteria",
-                  "type": "tuple[]"
-                }
-              ],
-              "internalType": "struct BlueprintComponent[]",
-              "name": "blueprint",
-              "type": "tuple[]"
-            },
-            { "internalType": "address", "name": "mutatorContract", "type": "address" },
-            { "internalType": "uint256", "name": "ethCostInWei", "type": "uint256" },
-            { "internalType": "address", "name": "feeRecipient", "type": "address" },
-            { "internalType": "string[7]", "name": "defaultTierImageUris", "type": "string[7]" },
-            { "internalType": "uint256", "name": "defaultCraftAmount", "type": "uint256" }
-          ],
-          "internalType": "struct Item",
-          "name": "",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
-      "name": "getItemIdForToken",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "uint256", "name": "itemId", "type": "uint256" },
-        { "internalType": "uint256", "name": "mintIndex", "type": "uint256" }
-      ],
-      "name": "getNonFungibleTokenId",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
-      "name": "getTokenDefaultImageUri",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "uint256", "name": "_tokenId", "type": "uint256" },
-        { "internalType": "string", "name": "_traitName", "type": "string" }
-      ],
-      "name": "getTokenTrait",
-      "outputs": [
-        {
-          "components": [
-            { "internalType": "string", "name": "typeName", "type": "string" },
-            { "internalType": "string", "name": "valueString", "type": "string" },
-            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-          ],
-          "internalType": "struct Trait",
-          "name": "",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
-      "name": "getTokenTraits",
-      "outputs": [
-        {
-          "components": [
-            { "internalType": "string", "name": "typeName", "type": "string" },
-            { "internalType": "string", "name": "valueString", "type": "string" },
-            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-          ],
-          "internalType": "struct Trait[]",
-          "name": "",
-          "type": "tuple[]"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "tokenId", "type": "uint256" }],
-      "name": "getTokenUri",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "address", "name": "_otomsAddress", "type": "address" },
-        { "internalType": "address", "name": "_otomsValidationAddress", "type": "address" }
-      ],
-      "name": "initialize",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "address", "name": "_owner", "type": "address" },
-        { "internalType": "address", "name": "_operator", "type": "address" },
-        { "internalType": "uint256", "name": "_itemId", "type": "uint256" }
-      ],
-      "name": "isApprovedForItem",
-      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "address", "name": "_owner", "type": "address" },
-        { "internalType": "address", "name": "_operator", "type": "address" },
-        { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
-      ],
-      "name": "isApprovedForToken",
-      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
-      "name": "isFungibleTokenId",
-      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "name": "itemMintCount",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "nextItemId",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
-      "name": "nonFungibleTokenToActualBlueprint",
-      "outputs": [
-        {
-          "components": [
-            { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-            { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-            { "internalType": "uint256", "name": "amount", "type": "uint256" },
-            {
-              "components": [
-                { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-                { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-                { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-                { "internalType": "bool", "name": "boolValue", "type": "bool" },
-                { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-                { "internalType": "string", "name": "stringValue", "type": "string" },
-                { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-                { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-                { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-              ],
-              "internalType": "struct PropertyCriterion[]",
-              "name": "criteria",
-              "type": "tuple[]"
-            }
-          ],
-          "internalType": "struct ActualBlueprintComponent[]",
-          "name": "",
-          "type": "tuple[]"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "name": "nonFungibleTokenToTier",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "address", "name": "_from", "type": "address" },
-        { "internalType": "address", "name": "_to", "type": "address" },
-        { "internalType": "uint256[]", "name": "_ids", "type": "uint256[]" },
-        { "internalType": "uint256[]", "name": "_values", "type": "uint256[]" }
-      ],
-      "name": "onUpdate",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "owner",
-      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "renounceOwnership",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "address", "name": "_operator", "type": "address" },
-        { "internalType": "uint256[]", "name": "_itemIds", "type": "uint256[]" },
-        { "internalType": "bool", "name": "_approved", "type": "bool" }
-      ],
-      "name": "setApprovalForItemIds",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "address", "name": "_operator", "type": "address" },
-        { "internalType": "uint256[]", "name": "_tokenIds", "type": "uint256[]" },
-        { "internalType": "bool", "name": "_approved", "type": "bool" }
-      ],
-      "name": "setApprovalForTokenIds",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "bool", "name": "isEnabled", "type": "bool" }],
-      "name": "setCreationEnabled",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
-        { "internalType": "address", "name": "_admin", "type": "address" }
-      ],
-      "name": "setItemAdmin",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "address", "name": "_otomItemsAddress", "type": "address" }],
-      "name": "setOtomItems",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "address", "name": "_rendererAddress", "type": "address" }],
-      "name": "setRenderer",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "address", "name": "_validatorAddress", "type": "address" }],
-      "name": "setValidator",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
-      "name": "transferOwnership",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
-        { "internalType": "string", "name": "_name", "type": "string" },
-        { "internalType": "string", "name": "_description", "type": "string" },
-        {
-          "components": [
-            { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-            { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-            { "internalType": "uint256", "name": "amount", "type": "uint256" },
-            {
-              "components": [
-                { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-                { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-                { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-                { "internalType": "bool", "name": "boolValue", "type": "bool" },
-                { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-                { "internalType": "string", "name": "stringValue", "type": "string" },
-                { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-                { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-                { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-              ],
-              "internalType": "struct PropertyCriterion[]",
-              "name": "criteria",
-              "type": "tuple[]"
-            }
-          ],
-          "internalType": "struct BlueprintComponent[]",
-          "name": "_blueprint",
-          "type": "tuple[]"
-        },
-        {
-          "components": [
-            { "internalType": "string", "name": "typeName", "type": "string" },
-            { "internalType": "string", "name": "valueString", "type": "string" },
-            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-          ],
-          "internalType": "struct Trait[]",
-          "name": "_traits",
-          "type": "tuple[]"
-        },
-        { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
-        { "internalType": "address", "name": "_feeRecipient", "type": "address" },
-        { "internalType": "uint256", "name": "_defaultCraftAmount", "type": "uint256" }
-      ],
-      "name": "updateFungibleItem",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
-        { "internalType": "string", "name": "_name", "type": "string" },
-        { "internalType": "string", "name": "_description", "type": "string" },
-        { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
-        { "internalType": "string[7]", "name": "_defaultTierImageUris", "type": "string[7]" },
-        {
-          "components": [
-            { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
-            { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
-            { "internalType": "uint256", "name": "amount", "type": "uint256" },
-            {
-              "components": [
-                { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
-                { "internalType": "uint256", "name": "minValue", "type": "uint256" },
-                { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
-                { "internalType": "bool", "name": "boolValue", "type": "bool" },
-                { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
-                { "internalType": "string", "name": "stringValue", "type": "string" },
-                { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
-                { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
-                { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
-              ],
-              "internalType": "struct PropertyCriterion[]",
-              "name": "criteria",
-              "type": "tuple[]"
-            }
-          ],
-          "internalType": "struct BlueprintComponent[]",
-          "name": "_blueprint",
-          "type": "tuple[]"
-        },
-        {
-          "components": [
-            { "internalType": "string", "name": "typeName", "type": "string" },
-            { "internalType": "string", "name": "valueString", "type": "string" },
-            { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
-            { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
-          ],
-          "internalType": "struct Trait[]",
-          "name": "_traits",
-          "type": "tuple[]"
-        },
-        { "internalType": "address", "name": "_mutatorContract", "type": "address" },
-        { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
-        { "internalType": "address", "name": "_feeRecipient", "type": "address" }
-      ],
-      "name": "updateNonFungibleItem",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "uint256", "name": "_tokenId", "type": "uint256" },
-        { "internalType": "address", "name": "_owner", "type": "address" },
-        { "internalType": "bytes", "name": "_data", "type": "bytes" }
-      ],
-      "name": "useItem",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    }
-  ]
-}
+[
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  { "inputs": [], "name": "CreationDisabled", "type": "error" },
+  { "inputs": [], "name": "CriteriaNotMet", "type": "error" },
+  { "inputs": [], "name": "InsufficientItemBalance", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+      { "internalType": "uint256", "name": "currentTier", "type": "uint256" },
+      { "internalType": "uint256", "name": "requiredTier", "type": "uint256" }
+    ],
+    "name": "InsufficientItemTier",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "required", "type": "uint256" },
+      { "internalType": "uint256", "name": "available", "type": "uint256" }
+    ],
+    "name": "InsufficientMatchingItems",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "required", "type": "uint256" },
+      { "internalType": "uint256", "name": "available", "type": "uint256" }
+    ],
+    "name": "InsufficientMatchingOtoms",
+    "type": "error"
+  },
+  { "inputs": [], "name": "InsufficientOtomBalance", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "required", "type": "uint256" },
+      { "internalType": "uint256", "name": "provided", "type": "uint256" }
+    ],
+    "name": "InsufficientPayment",
+    "type": "error"
+  },
+  { "inputs": [], "name": "InvalidBlueprintComponent", "type": "error" },
+  { "inputs": [], "name": "InvalidCraftAmount", "type": "error" },
+  { "inputs": [], "name": "InvalidFeeRecipient", "type": "error" },
+  { "inputs": [], "name": "InvalidInitialization", "type": "error" },
+  { "inputs": [], "name": "InvalidItem", "type": "error" },
+  { "inputs": [], "name": "InvalidName", "type": "error" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "tier", "type": "uint256" }],
+    "name": "InvalidTier",
+    "type": "error"
+  },
+  { "inputs": [], "name": "InvalidTraits", "type": "error" },
+  { "inputs": [], "name": "ItemAlreadyFrozen", "type": "error" },
+  { "inputs": [], "name": "ItemDoesNotExist", "type": "error" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "itemId", "type": "uint256" }],
+    "name": "ItemIsFrozen",
+    "type": "error"
+  },
+  { "inputs": [], "name": "MissingItemId", "type": "error" },
+  { "inputs": [], "name": "MutatorBlocked", "type": "error" },
+  { "inputs": [], "name": "MutatorFailed", "type": "error" },
+  { "inputs": [], "name": "NotAdmin", "type": "error" },
+  { "inputs": [], "name": "NotInitializing", "type": "error" },
+  { "inputs": [], "name": "NotOtomItems", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "msgSender", "type": "address" },
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "NotOwner",
+    "type": "error"
+  },
+  { "inputs": [], "name": "OnlyFungible", "type": "error" },
+  { "inputs": [], "name": "OnlyNonFungible", "type": "error" },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  { "inputs": [], "name": "PaymentFailed", "type": "error" },
+  { "inputs": [], "name": "ReentrancyGuardReentrantCall", "type": "error" },
+  { "inputs": [], "name": "TraitNotFound", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "bool", "name": "isEnabled", "type": "bool" }],
+    "name": "CreationEnabledSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "uint64", "name": "version", "type": "uint64" }],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "crafter", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+      {
+        "components": [
+          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" },
+          {
+            "components": [
+              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+              { "internalType": "bool", "name": "boolValue", "type": "bool" },
+              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+              { "internalType": "string", "name": "stringValue", "type": "string" },
+              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+            ],
+            "internalType": "struct PropertyCriterion[]",
+            "name": "criteria",
+            "type": "tuple[]"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ActualBlueprintComponent[]",
+        "name": "actualComponents",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "ItemCrafted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "creator", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
+      { "indexed": false, "internalType": "string", "name": "name", "type": "string" }
+    ],
+    "name": "ItemCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
+      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "ItemDestroyed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" }],
+    "name": "ItemFrozen",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" }],
+    "name": "ItemUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
+      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "ItemUsed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "uint256[]", "name": "itemIds", "type": "uint256[]" },
+      { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
+      { "indexed": false, "internalType": "bool", "name": "approved", "type": "bool" }
+    ],
+    "name": "ItemsApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "otomItems", "type": "address" }
+    ],
+    "name": "OtomItemsSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "renderer", "type": "address" }
+    ],
+    "name": "RendererSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "uint256[]", "name": "tokenIds", "type": "uint256[]" },
+      { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
+      { "indexed": false, "internalType": "bool", "name": "approved", "type": "bool" }
+    ],
+    "name": "TokensApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+      {
+        "components": [
+          { "internalType": "string", "name": "typeName", "type": "string" },
+          { "internalType": "string", "name": "valueString", "type": "string" },
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+        ],
+        "indexed": false,
+        "internalType": "struct Trait[]",
+        "name": "traits",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "TraitsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "validator", "type": "address" }
+    ],
+    "name": "ValidatorSet",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      { "internalType": "address", "name": "_owner", "type": "address" }
+    ],
+    "name": "consumeItem",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      { "internalType": "uint256[]", "name": "_variableOtomIds", "type": "uint256[]" },
+      { "internalType": "uint256[]", "name": "_nonFungibleTokenIds", "type": "uint256[]" },
+      { "internalType": "bytes", "name": "_data", "type": "bytes" }
+    ],
+    "name": "craftItem",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "string", "name": "_name", "type": "string" },
+      { "internalType": "string", "name": "_description", "type": "string" },
+      { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
+      {
+        "components": [
+          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" },
+          {
+            "components": [
+              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+              { "internalType": "bool", "name": "boolValue", "type": "bool" },
+              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+              { "internalType": "string", "name": "stringValue", "type": "string" },
+              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+            ],
+            "internalType": "struct PropertyCriterion[]",
+            "name": "criteria",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct BlueprintComponent[]",
+        "name": "_blueprint",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          { "internalType": "string", "name": "typeName", "type": "string" },
+          { "internalType": "string", "name": "valueString", "type": "string" },
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+        ],
+        "internalType": "struct Trait[]",
+        "name": "_traits",
+        "type": "tuple[]"
+      },
+      { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
+      { "internalType": "address", "name": "_feeRecipient", "type": "address" },
+      { "internalType": "uint256", "name": "_defaultCraftAmount", "type": "uint256" }
+    ],
+    "name": "createFungibleItem",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "string", "name": "_name", "type": "string" },
+      { "internalType": "string", "name": "_description", "type": "string" },
+      { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
+      { "internalType": "string[7]", "name": "_defaultTierImageUris", "type": "string[7]" },
+      {
+        "components": [
+          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" },
+          {
+            "components": [
+              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+              { "internalType": "bool", "name": "boolValue", "type": "bool" },
+              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+              { "internalType": "string", "name": "stringValue", "type": "string" },
+              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+            ],
+            "internalType": "struct PropertyCriterion[]",
+            "name": "criteria",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct BlueprintComponent[]",
+        "name": "_blueprint",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          { "internalType": "string", "name": "typeName", "type": "string" },
+          { "internalType": "string", "name": "valueString", "type": "string" },
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+        ],
+        "internalType": "struct Trait[]",
+        "name": "_traits",
+        "type": "tuple[]"
+      },
+      { "internalType": "address", "name": "_mutatorContract", "type": "address" },
+      { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
+      { "internalType": "address", "name": "_feeRecipient", "type": "address" }
+    ],
+    "name": "createNonFungibleItem",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "creationEnabled",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_itemId", "type": "uint256" }],
+    "name": "freezeItem",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "frozenItems",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_itemId", "type": "uint256" }],
+    "name": "getItemByItemId",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "id", "type": "uint256" },
+          { "internalType": "string", "name": "name", "type": "string" },
+          { "internalType": "string", "name": "description", "type": "string" },
+          { "internalType": "address", "name": "creator", "type": "address" },
+          { "internalType": "address", "name": "admin", "type": "address" },
+          { "internalType": "string", "name": "defaultImageUri", "type": "string" },
+          { "internalType": "enum ItemType", "name": "itemType", "type": "uint8" },
+          {
+            "components": [
+              { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+              { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+              { "internalType": "uint256", "name": "amount", "type": "uint256" },
+              {
+                "components": [
+                  { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+                  { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+                  { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+                  { "internalType": "bool", "name": "boolValue", "type": "bool" },
+                  { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+                  { "internalType": "string", "name": "stringValue", "type": "string" },
+                  { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+                  { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+                  { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+                ],
+                "internalType": "struct PropertyCriterion[]",
+                "name": "criteria",
+                "type": "tuple[]"
+              }
+            ],
+            "internalType": "struct BlueprintComponent[]",
+            "name": "blueprint",
+            "type": "tuple[]"
+          },
+          { "internalType": "address", "name": "mutatorContract", "type": "address" },
+          { "internalType": "uint256", "name": "ethCostInWei", "type": "uint256" },
+          { "internalType": "address", "name": "feeRecipient", "type": "address" },
+          { "internalType": "string[7]", "name": "defaultTierImageUris", "type": "string[7]" },
+          { "internalType": "uint256", "name": "defaultCraftAmount", "type": "uint256" }
+        ],
+        "internalType": "struct Item",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
+    "name": "getItemIdForToken",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "itemId", "type": "uint256" },
+      { "internalType": "uint256", "name": "mintIndex", "type": "uint256" }
+    ],
+    "name": "getNonFungibleTokenId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" },
+      { "internalType": "string", "name": "_traitName", "type": "string" }
+    ],
+    "name": "getTokenTrait",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "string", "name": "typeName", "type": "string" },
+          { "internalType": "string", "name": "valueString", "type": "string" },
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+        ],
+        "internalType": "struct Trait",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
+    "name": "getTokenTraits",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "string", "name": "typeName", "type": "string" },
+          { "internalType": "string", "name": "valueString", "type": "string" },
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+        ],
+        "internalType": "struct Trait[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "tokenId", "type": "uint256" }],
+    "name": "getTokenUri",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_otomsAddress", "type": "address" },
+      { "internalType": "address", "name": "_otomsValidationAddress", "type": "address" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_owner", "type": "address" },
+      { "internalType": "address", "name": "_operator", "type": "address" },
+      { "internalType": "uint256", "name": "_itemId", "type": "uint256" }
+    ],
+    "name": "isApprovedForItem",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_owner", "type": "address" },
+      { "internalType": "address", "name": "_operator", "type": "address" },
+      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
+    ],
+    "name": "isApprovedForToken",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
+    "name": "isFungibleTokenId",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "itemMintCount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nextItemId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
+    "name": "nonFungibleTokenToActualBlueprint",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" },
+          {
+            "components": [
+              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+              { "internalType": "bool", "name": "boolValue", "type": "bool" },
+              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+              { "internalType": "string", "name": "stringValue", "type": "string" },
+              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+            ],
+            "internalType": "struct PropertyCriterion[]",
+            "name": "criteria",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct ActualBlueprintComponent[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "nonFungibleTokenToTier",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_from", "type": "address" },
+      { "internalType": "address", "name": "_to", "type": "address" },
+      { "internalType": "uint256[]", "name": "_ids", "type": "uint256[]" },
+      { "internalType": "uint256[]", "name": "_values", "type": "uint256[]" }
+    ],
+    "name": "onUpdate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_operator", "type": "address" },
+      { "internalType": "uint256[]", "name": "_itemIds", "type": "uint256[]" },
+      { "internalType": "bool", "name": "_approved", "type": "bool" }
+    ],
+    "name": "setApprovalForItemIds",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_operator", "type": "address" },
+      { "internalType": "uint256[]", "name": "_tokenIds", "type": "uint256[]" },
+      { "internalType": "bool", "name": "_approved", "type": "bool" }
+    ],
+    "name": "setApprovalForTokenIds",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bool", "name": "isEnabled", "type": "bool" }],
+    "name": "setCreationEnabled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
+      { "internalType": "address", "name": "_admin", "type": "address" }
+    ],
+    "name": "setItemAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_otomItemsAddress", "type": "address" }],
+    "name": "setOtomItems",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_rendererAddress", "type": "address" }],
+    "name": "setRenderer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_validatorAddress", "type": "address" }],
+    "name": "setValidator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
+      { "internalType": "string", "name": "_name", "type": "string" },
+      { "internalType": "string", "name": "_description", "type": "string" },
+      {
+        "components": [
+          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" },
+          {
+            "components": [
+              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+              { "internalType": "bool", "name": "boolValue", "type": "bool" },
+              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+              { "internalType": "string", "name": "stringValue", "type": "string" },
+              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+            ],
+            "internalType": "struct PropertyCriterion[]",
+            "name": "criteria",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct BlueprintComponent[]",
+        "name": "_blueprint",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          { "internalType": "string", "name": "typeName", "type": "string" },
+          { "internalType": "string", "name": "valueString", "type": "string" },
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+        ],
+        "internalType": "struct Trait[]",
+        "name": "_traits",
+        "type": "tuple[]"
+      },
+      { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
+      { "internalType": "address", "name": "_feeRecipient", "type": "address" },
+      { "internalType": "uint256", "name": "_defaultCraftAmount", "type": "uint256" }
+    ],
+    "name": "updateFungibleItem",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
+      { "internalType": "string", "name": "_name", "type": "string" },
+      { "internalType": "string", "name": "_description", "type": "string" },
+      { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
+      { "internalType": "string[7]", "name": "_defaultTierImageUris", "type": "string[7]" },
+      {
+        "components": [
+          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" },
+          {
+            "components": [
+              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+              { "internalType": "bool", "name": "boolValue", "type": "bool" },
+              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+              { "internalType": "string", "name": "stringValue", "type": "string" },
+              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
+            ],
+            "internalType": "struct PropertyCriterion[]",
+            "name": "criteria",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct BlueprintComponent[]",
+        "name": "_blueprint",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          { "internalType": "string", "name": "typeName", "type": "string" },
+          { "internalType": "string", "name": "valueString", "type": "string" },
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
+        ],
+        "internalType": "struct Trait[]",
+        "name": "_traits",
+        "type": "tuple[]"
+      },
+      { "internalType": "address", "name": "_mutatorContract", "type": "address" },
+      { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
+      { "internalType": "address", "name": "_feeRecipient", "type": "address" }
+    ],
+    "name": "updateNonFungibleItem",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" },
+      { "internalType": "address", "name": "_owner", "type": "address" },
+      { "internalType": "bytes", "name": "_data", "type": "bytes" }
+    ],
+    "name": "useItem",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/apps/web/generated.ts
+++ b/apps/web/generated.ts
@@ -825,13 +825,6 @@ export const otomItemsCoreContractAbi = [
   },
   {
     type: 'function',
-    inputs: [{ name: '_tokenId', internalType: 'uint256', type: 'uint256' }],
-    name: 'getTokenDefaultImageUri',
-    outputs: [{ name: '', internalType: 'string', type: 'string' }],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
     inputs: [
       { name: '_tokenId', internalType: 'uint256', type: 'uint256' },
       { name: '_traitName', internalType: 'string', type: 'string' },
@@ -3780,15 +3773,6 @@ export const useReadOtomItemsCoreContractGetNonFungibleTokenId =
   /*#__PURE__*/ createUseReadContract({
     abi: otomItemsCoreContractAbi,
     functionName: 'getNonFungibleTokenId',
-  });
-
-/**
- * Wraps __{@link useReadContract}__ with `abi` set to __{@link otomItemsCoreContractAbi}__ and `functionName` set to `"getTokenDefaultImageUri"`
- */
-export const useReadOtomItemsCoreContractGetTokenDefaultImageUri =
-  /*#__PURE__*/ createUseReadContract({
-    abi: otomItemsCoreContractAbi,
-    functionName: 'getTokenDefaultImageUri',
   });
 
 /**

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "wagmi:generate": "wagmi generate --config ./wagmi.config.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/packages/contracts/contracts/interfaces/IOtomItemMutator.sol
+++ b/packages/contracts/contracts/interfaces/IOtomItemMutator.sol
@@ -84,4 +84,12 @@ interface IOtomItemMutator {
         uint256[] calldata _nonFungibleTokenIds,
         bytes calldata _data
     ) external returns (bool allowed, bool requiresItemsOrOtoms);
+
+    /**
+     * @dev Image override for a given item
+     * @param tokenId The token ID of the item
+     * @param tier The tier of the item
+     * @return image The image for the item given the token ID and tier
+     */
+    function getItemImage(uint256 tokenId, uint256 tier) external view returns (string memory);
 }

--- a/packages/contracts/contracts/interfaces/IOtomItemsCore.sol
+++ b/packages/contracts/contracts/interfaces/IOtomItemsCore.sol
@@ -239,8 +239,6 @@ interface IOtomItemsCore {
 
     function getTokenUri(uint256 _tokenId) external view returns (string memory);
 
-    function getTokenDefaultImageUri(uint256 _tokenId) external view returns (string memory);
-
     function isFungibleTokenId(uint256 _tokenId) external view returns (bool);
 
     function nonFungibleTokenToTier(uint256 _tokenId) external view returns (uint256);

--- a/packages/contracts/contracts/interfaces/IOtomItemsRenderer.sol
+++ b/packages/contracts/contracts/interfaces/IOtomItemsRenderer.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.26;
 
 interface IOtomItemsRenderer {
     error InvalidTraitType();
+    error InvalidItem();
+    error MutatorFailed();
 
     function getMetadata(uint256 tokenId) external view returns (string memory);
 }

--- a/packages/contracts/contracts/items/OtomItemsCore.sol
+++ b/packages/contracts/contracts/items/OtomItemsCore.sol
@@ -1229,33 +1229,6 @@ contract OtomItemsCore is
     }
 
     /**
-     * @dev Gets the appropriate image URI for a token based on its tier
-     * @param _tokenId The token ID
-     * @return The image URI
-     */
-    function getTokenDefaultImageUri(uint256 _tokenId) external view returns (string memory) {
-        if (isFungibleTokenId(_tokenId)) {
-            // For fungible tokens, return the default image URI
-            uint256 itemId = getItemIdForToken(_tokenId);
-            return _items[itemId].defaultImageUri;
-        } else {
-            // For non-fungible tokens, get the tier and return the appropriate image URI
-            uint256 itemId = _nonFungibleTokenToItemId[_tokenId];
-            if (itemId == 0) revert InvalidItem();
-
-            uint256 tier = nonFungibleTokenToTier[_tokenId];
-
-            // If tier is 0 or the tier image URI is empty, return the default image URI
-            if (tier == 0 || bytes(_items[itemId].defaultTierImageUris[tier - 1]).length == 0) {
-                return _items[itemId].defaultImageUri;
-            }
-
-            // Otherwise, return the tier-specific default image URI
-            return _items[itemId].defaultTierImageUris[tier - 1];
-        }
-    }
-
-    /**
      * @dev Checks if an address is approved for a specific item ID
      * @param _owner The token owner
      * @param _operator The potential operator address

--- a/packages/contracts/contracts/items/mutators/GenericMutator.sol
+++ b/packages/contracts/contracts/items/mutators/GenericMutator.sol
@@ -134,4 +134,8 @@ contract GenericMutator is IOtomItemMutator {
         // Only allow crafting 1 item at a time
         requiresItemsOrOtoms = _amount == 1;
     }
+
+    function getItemImage(uint256, uint256) external pure override returns (string memory) {
+        return "";
+    }
 }

--- a/packages/contracts/contracts/items/mutators/PickaxeMutator.sol
+++ b/packages/contracts/contracts/items/mutators/PickaxeMutator.sol
@@ -21,10 +21,7 @@ contract PickaxeMutator is IOtomItemMutator, Ownable2Step {
 
     IOtomsDatabase public immutable OTOMS_DATABASE;
 
-    constructor(
-        address _otomsDatabase,
-        uint256[] memory _tierToUsesRemaining
-    ) Ownable(msg.sender) {
+    constructor(address _otomsDatabase, uint256[] memory _tierToUsesRemaining) Ownable(msg.sender) {
         if (_tierToUsesRemaining.length != 5) revert MissingTiers();
 
         OTOMS_DATABASE = IOtomsDatabase(_otomsDatabase);
@@ -34,9 +31,7 @@ contract PickaxeMutator is IOtomItemMutator, Ownable2Step {
         }
     }
 
-    function setTierToUsesRemaining(
-        uint256[] memory _tierToUsesRemaining
-    ) external onlyOwner {
+    function setTierToUsesRemaining(uint256[] memory _tierToUsesRemaining) external onlyOwner {
         if (_tierToUsesRemaining.length != 5) revert MissingTiers();
 
         for (uint256 i = 0; i < _tierToUsesRemaining.length; i++) {
@@ -50,12 +45,7 @@ contract PickaxeMutator is IOtomItemMutator, Ownable2Step {
         uint256[] memory,
         Trait[] memory baseTraits,
         uint256 paymentAmount
-    )
-        external
-        view
-        override
-        returns (uint256 tierLevel, Trait[] memory modifiedTraits)
-    {
+    ) external view override returns (uint256 tierLevel, Trait[] memory modifiedTraits) {
         if (paymentAmount == 0 && variableOtomIds.length == 0) {
             return (0, baseTraits);
         }
@@ -66,9 +56,7 @@ contract PickaxeMutator is IOtomItemMutator, Ownable2Step {
         // Example: Sum the hardness values of all variable otoms
         for (uint256 i = 0; i < variableOtomIds.length; i++) {
             uint256 totalMassOfMolecule = 0;
-            Molecule memory molecule = OTOMS_DATABASE.getMoleculeByTokenId(
-                variableOtomIds[i]
-            );
+            Molecule memory molecule = OTOMS_DATABASE.getMoleculeByTokenId(variableOtomIds[i]);
 
             for (uint256 j = 0; j < molecule.givingAtoms.length; j++) {
                 totalMassOfMolecule += molecule.givingAtoms[j].mass;
@@ -137,9 +125,7 @@ contract PickaxeMutator is IOtomItemMutator, Ownable2Step {
                 }
 
                 updatedTraits[i].valueNumber--;
-                updatedTraits[i].valueString = updatedTraits[i]
-                    .valueNumber
-                    .toString();
+                updatedTraits[i].valueString = updatedTraits[i].valueNumber.toString();
 
                 if (updatedTraits[i].valueNumber == 0) {
                     shouldDestroy = true;
@@ -171,5 +157,9 @@ contract PickaxeMutator is IOtomItemMutator, Ownable2Step {
         bytes calldata
     ) external pure override returns (bool, bool) {
         return (true, true);
+    }
+
+    function getItemImage(uint256, uint256) external pure override returns (string memory) {
+        return "";
     }
 }

--- a/packages/contracts/contracts/items/mutators/SwordMutator.sol
+++ b/packages/contracts/contracts/items/mutators/SwordMutator.sol
@@ -126,4 +126,8 @@ contract SwordMutator is IOtomItemMutator {
     ) external pure override returns (bool, bool) {
         return (true, true);
     }
+
+    function getItemImage(uint256, uint256) external pure override returns (string memory) {
+        return "";
+    }
 }

--- a/packages/subgraph/abis/OtomItemsCore.json
+++ b/packages/subgraph/abis/OtomItemsCore.json
@@ -44,9 +44,7 @@
   { "inputs": [], "name": "InvalidItem", "type": "error" },
   { "inputs": [], "name": "InvalidName", "type": "error" },
   {
-    "inputs": [
-      { "internalType": "uint256", "name": "tier", "type": "uint256" }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "tier", "type": "uint256" }],
     "name": "InvalidTier",
     "type": "error"
   },
@@ -54,9 +52,7 @@
   { "inputs": [], "name": "ItemAlreadyFrozen", "type": "error" },
   { "inputs": [], "name": "ItemDoesNotExist", "type": "error" },
   {
-    "inputs": [
-      { "internalType": "uint256", "name": "itemId", "type": "uint256" }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "itemId", "type": "uint256" }],
     "name": "ItemIsFrozen",
     "type": "error"
   },
@@ -77,16 +73,12 @@
   { "inputs": [], "name": "OnlyFungible", "type": "error" },
   { "inputs": [], "name": "OnlyNonFungible", "type": "error" },
   {
-    "inputs": [
-      { "internalType": "address", "name": "owner", "type": "address" }
-    ],
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
     "name": "OwnableInvalidOwner",
     "type": "error"
   },
   {
-    "inputs": [
-      { "internalType": "address", "name": "account", "type": "address" }
-    ],
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
     "name": "OwnableUnauthorizedAccount",
     "type": "error"
   },
@@ -95,113 +87,39 @@
   { "inputs": [], "name": "TraitNotFound", "type": "error" },
   {
     "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bool",
-        "name": "isEnabled",
-        "type": "bool"
-      }
-    ],
+    "inputs": [{ "indexed": true, "internalType": "bool", "name": "isEnabled", "type": "bool" }],
     "name": "CreationEnabledSet",
     "type": "event"
   },
   {
     "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint64",
-        "name": "version",
-        "type": "uint64"
-      }
-    ],
+    "inputs": [{ "indexed": false, "internalType": "uint64", "name": "version", "type": "uint64" }],
     "name": "Initialized",
     "type": "event"
   },
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "crafter",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "itemId",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "tokenId",
-        "type": "uint256"
-      },
+      { "indexed": true, "internalType": "address", "name": "crafter", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
       {
         "components": [
-          {
-            "internalType": "enum ComponentType",
-            "name": "componentType",
-            "type": "uint8"
-          },
-          {
-            "internalType": "uint256",
-            "name": "itemIdOrOtomTokenId",
-            "type": "uint256"
-          },
+          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
           { "internalType": "uint256", "name": "amount", "type": "uint256" },
           {
             "components": [
-              {
-                "internalType": "enum PropertyType",
-                "name": "propertyType",
-                "type": "uint8"
-              },
-              {
-                "internalType": "uint256",
-                "name": "minValue",
-                "type": "uint256"
-              },
-              {
-                "internalType": "uint256",
-                "name": "maxValue",
-                "type": "uint256"
-              },
+              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
               { "internalType": "bool", "name": "boolValue", "type": "bool" },
-              {
-                "internalType": "bool",
-                "name": "checkBoolValue",
-                "type": "bool"
-              },
-              {
-                "internalType": "string",
-                "name": "stringValue",
-                "type": "string"
-              },
-              {
-                "internalType": "bool",
-                "name": "checkStringValue",
-                "type": "bool"
-              },
-              {
-                "internalType": "bytes32",
-                "name": "bytes32Value",
-                "type": "bytes32"
-              },
-              {
-                "internalType": "bool",
-                "name": "checkBytes32Value",
-                "type": "bool"
-              }
+              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+              { "internalType": "string", "name": "stringValue", "type": "string" },
+              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
             ],
             "internalType": "struct PropertyCriterion[]",
             "name": "criteria",
@@ -220,24 +138,9 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "creator",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "itemId",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "name",
-        "type": "string"
-      }
+      { "indexed": true, "internalType": "address", "name": "creator", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
+      { "indexed": false, "internalType": "string", "name": "name", "type": "string" }
     ],
     "name": "ItemCreated",
     "type": "event"
@@ -245,75 +148,31 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "user",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "itemId",
-        "type": "uint256"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "tokenId",
-        "type": "uint256"
-      }
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
+      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" }
     ],
     "name": "ItemDestroyed",
     "type": "event"
   },
   {
     "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "itemId",
-        "type": "uint256"
-      }
-    ],
+    "inputs": [{ "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" }],
     "name": "ItemFrozen",
     "type": "event"
   },
   {
     "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "itemId",
-        "type": "uint256"
-      }
-    ],
+    "inputs": [{ "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" }],
     "name": "ItemUpdated",
     "type": "event"
   },
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "user",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "itemId",
-        "type": "uint256"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "tokenId",
-        "type": "uint256"
-      }
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "itemId", "type": "uint256" },
+      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" }
     ],
     "name": "ItemUsed",
     "type": "event"
@@ -321,30 +180,10 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256[]",
-        "name": "itemIds",
-        "type": "uint256[]"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "operator",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bool",
-        "name": "approved",
-        "type": "bool"
-      }
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "uint256[]", "name": "itemIds", "type": "uint256[]" },
+      { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
+      { "indexed": false, "internalType": "bool", "name": "approved", "type": "bool" }
     ],
     "name": "ItemsApprovalForAll",
     "type": "event"
@@ -352,12 +191,7 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "otomItems",
-        "type": "address"
-      }
+      { "indexed": true, "internalType": "address", "name": "otomItems", "type": "address" }
     ],
     "name": "OtomItemsSet",
     "type": "event"
@@ -365,18 +199,8 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
     ],
     "name": "OwnershipTransferred",
     "type": "event"
@@ -384,12 +208,7 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "renderer",
-        "type": "address"
-      }
+      { "indexed": true, "internalType": "address", "name": "renderer", "type": "address" }
     ],
     "name": "RendererSet",
     "type": "event"
@@ -397,30 +216,10 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256[]",
-        "name": "tokenIds",
-        "type": "uint256[]"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "operator",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bool",
-        "name": "approved",
-        "type": "bool"
-      }
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "uint256[]", "name": "tokenIds", "type": "uint256[]" },
+      { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
+      { "indexed": false, "internalType": "bool", "name": "approved", "type": "bool" }
     ],
     "name": "TokensApprovalForAll",
     "type": "event"
@@ -428,26 +227,13 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "tokenId",
-        "type": "uint256"
-      },
+      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
       {
         "components": [
           { "internalType": "string", "name": "typeName", "type": "string" },
           { "internalType": "string", "name": "valueString", "type": "string" },
-          {
-            "internalType": "uint256",
-            "name": "valueNumber",
-            "type": "uint256"
-          },
-          {
-            "internalType": "enum TraitType",
-            "name": "traitType",
-            "type": "uint8"
-          }
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
         ],
         "indexed": false,
         "internalType": "struct Trait[]",
@@ -461,12 +247,7 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "validator",
-        "type": "address"
-      }
+      { "indexed": true, "internalType": "address", "name": "validator", "type": "address" }
     ],
     "name": "ValidatorSet",
     "type": "event"
@@ -486,16 +267,8 @@
     "inputs": [
       { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
       { "internalType": "uint256", "name": "_amount", "type": "uint256" },
-      {
-        "internalType": "uint256[]",
-        "name": "_variableOtomIds",
-        "type": "uint256[]"
-      },
-      {
-        "internalType": "uint256[]",
-        "name": "_nonFungibleTokenIds",
-        "type": "uint256[]"
-      },
+      { "internalType": "uint256[]", "name": "_variableOtomIds", "type": "uint256[]" },
+      { "internalType": "uint256[]", "name": "_nonFungibleTokenIds", "type": "uint256[]" },
       { "internalType": "bytes", "name": "_data", "type": "bytes" }
     ],
     "name": "craftItem",
@@ -507,67 +280,23 @@
     "inputs": [
       { "internalType": "string", "name": "_name", "type": "string" },
       { "internalType": "string", "name": "_description", "type": "string" },
-      {
-        "internalType": "string",
-        "name": "_defaultImageUri",
-        "type": "string"
-      },
+      { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
       {
         "components": [
-          {
-            "internalType": "enum ComponentType",
-            "name": "componentType",
-            "type": "uint8"
-          },
-          {
-            "internalType": "uint256",
-            "name": "itemIdOrOtomTokenId",
-            "type": "uint256"
-          },
+          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
           { "internalType": "uint256", "name": "amount", "type": "uint256" },
           {
             "components": [
-              {
-                "internalType": "enum PropertyType",
-                "name": "propertyType",
-                "type": "uint8"
-              },
-              {
-                "internalType": "uint256",
-                "name": "minValue",
-                "type": "uint256"
-              },
-              {
-                "internalType": "uint256",
-                "name": "maxValue",
-                "type": "uint256"
-              },
+              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
               { "internalType": "bool", "name": "boolValue", "type": "bool" },
-              {
-                "internalType": "bool",
-                "name": "checkBoolValue",
-                "type": "bool"
-              },
-              {
-                "internalType": "string",
-                "name": "stringValue",
-                "type": "string"
-              },
-              {
-                "internalType": "bool",
-                "name": "checkStringValue",
-                "type": "bool"
-              },
-              {
-                "internalType": "bytes32",
-                "name": "bytes32Value",
-                "type": "bytes32"
-              },
-              {
-                "internalType": "bool",
-                "name": "checkBytes32Value",
-                "type": "bool"
-              }
+              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+              { "internalType": "string", "name": "stringValue", "type": "string" },
+              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
             ],
             "internalType": "struct PropertyCriterion[]",
             "name": "criteria",
@@ -582,16 +311,8 @@
         "components": [
           { "internalType": "string", "name": "typeName", "type": "string" },
           { "internalType": "string", "name": "valueString", "type": "string" },
-          {
-            "internalType": "uint256",
-            "name": "valueNumber",
-            "type": "uint256"
-          },
-          {
-            "internalType": "enum TraitType",
-            "name": "traitType",
-            "type": "uint8"
-          }
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
         ],
         "internalType": "struct Trait[]",
         "name": "_traits",
@@ -599,11 +320,7 @@
       },
       { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
       { "internalType": "address", "name": "_feeRecipient", "type": "address" },
-      {
-        "internalType": "uint256",
-        "name": "_defaultCraftAmount",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "_defaultCraftAmount", "type": "uint256" }
     ],
     "name": "createFungibleItem",
     "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
@@ -614,72 +331,24 @@
     "inputs": [
       { "internalType": "string", "name": "_name", "type": "string" },
       { "internalType": "string", "name": "_description", "type": "string" },
-      {
-        "internalType": "string",
-        "name": "_defaultImageUri",
-        "type": "string"
-      },
-      {
-        "internalType": "string[7]",
-        "name": "_defaultTierImageUris",
-        "type": "string[7]"
-      },
+      { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
+      { "internalType": "string[7]", "name": "_defaultTierImageUris", "type": "string[7]" },
       {
         "components": [
-          {
-            "internalType": "enum ComponentType",
-            "name": "componentType",
-            "type": "uint8"
-          },
-          {
-            "internalType": "uint256",
-            "name": "itemIdOrOtomTokenId",
-            "type": "uint256"
-          },
+          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
           { "internalType": "uint256", "name": "amount", "type": "uint256" },
           {
             "components": [
-              {
-                "internalType": "enum PropertyType",
-                "name": "propertyType",
-                "type": "uint8"
-              },
-              {
-                "internalType": "uint256",
-                "name": "minValue",
-                "type": "uint256"
-              },
-              {
-                "internalType": "uint256",
-                "name": "maxValue",
-                "type": "uint256"
-              },
+              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
               { "internalType": "bool", "name": "boolValue", "type": "bool" },
-              {
-                "internalType": "bool",
-                "name": "checkBoolValue",
-                "type": "bool"
-              },
-              {
-                "internalType": "string",
-                "name": "stringValue",
-                "type": "string"
-              },
-              {
-                "internalType": "bool",
-                "name": "checkStringValue",
-                "type": "bool"
-              },
-              {
-                "internalType": "bytes32",
-                "name": "bytes32Value",
-                "type": "bytes32"
-              },
-              {
-                "internalType": "bool",
-                "name": "checkBytes32Value",
-                "type": "bool"
-              }
+              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+              { "internalType": "string", "name": "stringValue", "type": "string" },
+              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
             ],
             "internalType": "struct PropertyCriterion[]",
             "name": "criteria",
@@ -694,26 +363,14 @@
         "components": [
           { "internalType": "string", "name": "typeName", "type": "string" },
           { "internalType": "string", "name": "valueString", "type": "string" },
-          {
-            "internalType": "uint256",
-            "name": "valueNumber",
-            "type": "uint256"
-          },
-          {
-            "internalType": "enum TraitType",
-            "name": "traitType",
-            "type": "uint8"
-          }
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
         ],
         "internalType": "struct Trait[]",
         "name": "_traits",
         "type": "tuple[]"
       },
-      {
-        "internalType": "address",
-        "name": "_mutatorContract",
-        "type": "address"
-      },
+      { "internalType": "address", "name": "_mutatorContract", "type": "address" },
       { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
       { "internalType": "address", "name": "_feeRecipient", "type": "address" }
     ],
@@ -730,9 +387,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      { "internalType": "uint256", "name": "_itemId", "type": "uint256" }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "_itemId", "type": "uint256" }],
     "name": "freezeItem",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -746,9 +401,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      { "internalType": "uint256", "name": "_itemId", "type": "uint256" }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "_itemId", "type": "uint256" }],
     "name": "getItemByItemId",
     "outputs": [
       {
@@ -758,80 +411,24 @@
           { "internalType": "string", "name": "description", "type": "string" },
           { "internalType": "address", "name": "creator", "type": "address" },
           { "internalType": "address", "name": "admin", "type": "address" },
-          {
-            "internalType": "string",
-            "name": "defaultImageUri",
-            "type": "string"
-          },
-          {
-            "internalType": "enum ItemType",
-            "name": "itemType",
-            "type": "uint8"
-          },
+          { "internalType": "string", "name": "defaultImageUri", "type": "string" },
+          { "internalType": "enum ItemType", "name": "itemType", "type": "uint8" },
           {
             "components": [
-              {
-                "internalType": "enum ComponentType",
-                "name": "componentType",
-                "type": "uint8"
-              },
-              {
-                "internalType": "uint256",
-                "name": "itemIdOrOtomTokenId",
-                "type": "uint256"
-              },
-              {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-              },
+              { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+              { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
+              { "internalType": "uint256", "name": "amount", "type": "uint256" },
               {
                 "components": [
-                  {
-                    "internalType": "enum PropertyType",
-                    "name": "propertyType",
-                    "type": "uint8"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "minValue",
-                    "type": "uint256"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "maxValue",
-                    "type": "uint256"
-                  },
-                  {
-                    "internalType": "bool",
-                    "name": "boolValue",
-                    "type": "bool"
-                  },
-                  {
-                    "internalType": "bool",
-                    "name": "checkBoolValue",
-                    "type": "bool"
-                  },
-                  {
-                    "internalType": "string",
-                    "name": "stringValue",
-                    "type": "string"
-                  },
-                  {
-                    "internalType": "bool",
-                    "name": "checkStringValue",
-                    "type": "bool"
-                  },
-                  {
-                    "internalType": "bytes32",
-                    "name": "bytes32Value",
-                    "type": "bytes32"
-                  },
-                  {
-                    "internalType": "bool",
-                    "name": "checkBytes32Value",
-                    "type": "bool"
-                  }
+                  { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+                  { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+                  { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
+                  { "internalType": "bool", "name": "boolValue", "type": "bool" },
+                  { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+                  { "internalType": "string", "name": "stringValue", "type": "string" },
+                  { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+                  { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+                  { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
                 ],
                 "internalType": "struct PropertyCriterion[]",
                 "name": "criteria",
@@ -842,31 +439,11 @@
             "name": "blueprint",
             "type": "tuple[]"
           },
-          {
-            "internalType": "address",
-            "name": "mutatorContract",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "ethCostInWei",
-            "type": "uint256"
-          },
-          {
-            "internalType": "address",
-            "name": "feeRecipient",
-            "type": "address"
-          },
-          {
-            "internalType": "string[7]",
-            "name": "defaultTierImageUris",
-            "type": "string[7]"
-          },
-          {
-            "internalType": "uint256",
-            "name": "defaultCraftAmount",
-            "type": "uint256"
-          }
+          { "internalType": "address", "name": "mutatorContract", "type": "address" },
+          { "internalType": "uint256", "name": "ethCostInWei", "type": "uint256" },
+          { "internalType": "address", "name": "feeRecipient", "type": "address" },
+          { "internalType": "string[7]", "name": "defaultTierImageUris", "type": "string[7]" },
+          { "internalType": "uint256", "name": "defaultCraftAmount", "type": "uint256" }
         ],
         "internalType": "struct Item",
         "name": "",
@@ -877,9 +454,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
     "name": "getItemIdForToken",
     "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
@@ -897,15 +472,6 @@
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
-    ],
-    "name": "getTokenDefaultImageUri",
-    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
       { "internalType": "uint256", "name": "_tokenId", "type": "uint256" },
       { "internalType": "string", "name": "_traitName", "type": "string" }
     ],
@@ -915,16 +481,8 @@
         "components": [
           { "internalType": "string", "name": "typeName", "type": "string" },
           { "internalType": "string", "name": "valueString", "type": "string" },
-          {
-            "internalType": "uint256",
-            "name": "valueNumber",
-            "type": "uint256"
-          },
-          {
-            "internalType": "enum TraitType",
-            "name": "traitType",
-            "type": "uint8"
-          }
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
         ],
         "internalType": "struct Trait",
         "name": "",
@@ -935,25 +493,15 @@
     "type": "function"
   },
   {
-    "inputs": [
-      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
     "name": "getTokenTraits",
     "outputs": [
       {
         "components": [
           { "internalType": "string", "name": "typeName", "type": "string" },
           { "internalType": "string", "name": "valueString", "type": "string" },
-          {
-            "internalType": "uint256",
-            "name": "valueNumber",
-            "type": "uint256"
-          },
-          {
-            "internalType": "enum TraitType",
-            "name": "traitType",
-            "type": "uint8"
-          }
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
         ],
         "internalType": "struct Trait[]",
         "name": "",
@@ -964,9 +512,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "tokenId", "type": "uint256" }],
     "name": "getTokenUri",
     "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
     "stateMutability": "view",
@@ -975,11 +521,7 @@
   {
     "inputs": [
       { "internalType": "address", "name": "_otomsAddress", "type": "address" },
-      {
-        "internalType": "address",
-        "name": "_otomsValidationAddress",
-        "type": "address"
-      }
+      { "internalType": "address", "name": "_otomsValidationAddress", "type": "address" }
     ],
     "name": "initialize",
     "outputs": [],
@@ -1009,9 +551,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
     "name": "isFungibleTokenId",
     "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
     "stateMutability": "pure",
@@ -1032,67 +572,25 @@
     "type": "function"
   },
   {
-    "inputs": [
-      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
-    ],
+    "inputs": [{ "internalType": "uint256", "name": "_tokenId", "type": "uint256" }],
     "name": "nonFungibleTokenToActualBlueprint",
     "outputs": [
       {
         "components": [
-          {
-            "internalType": "enum ComponentType",
-            "name": "componentType",
-            "type": "uint8"
-          },
-          {
-            "internalType": "uint256",
-            "name": "itemIdOrOtomTokenId",
-            "type": "uint256"
-          },
+          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
           { "internalType": "uint256", "name": "amount", "type": "uint256" },
           {
             "components": [
-              {
-                "internalType": "enum PropertyType",
-                "name": "propertyType",
-                "type": "uint8"
-              },
-              {
-                "internalType": "uint256",
-                "name": "minValue",
-                "type": "uint256"
-              },
-              {
-                "internalType": "uint256",
-                "name": "maxValue",
-                "type": "uint256"
-              },
+              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
               { "internalType": "bool", "name": "boolValue", "type": "bool" },
-              {
-                "internalType": "bool",
-                "name": "checkBoolValue",
-                "type": "bool"
-              },
-              {
-                "internalType": "string",
-                "name": "stringValue",
-                "type": "string"
-              },
-              {
-                "internalType": "bool",
-                "name": "checkStringValue",
-                "type": "bool"
-              },
-              {
-                "internalType": "bytes32",
-                "name": "bytes32Value",
-                "type": "bytes32"
-              },
-              {
-                "internalType": "bool",
-                "name": "checkBytes32Value",
-                "type": "bool"
-              }
+              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+              { "internalType": "string", "name": "stringValue", "type": "string" },
+              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
             ],
             "internalType": "struct PropertyCriterion[]",
             "name": "criteria",
@@ -1180,48 +678,28 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_otomItemsAddress",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "_otomItemsAddress", "type": "address" }],
     "name": "setOtomItems",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_rendererAddress",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "_rendererAddress", "type": "address" }],
     "name": "setRenderer",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_validatorAddress",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "_validatorAddress", "type": "address" }],
     "name": "setValidator",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [
-      { "internalType": "address", "name": "newOwner", "type": "address" }
-    ],
+    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
     "name": "transferOwnership",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -1234,60 +712,20 @@
       { "internalType": "string", "name": "_description", "type": "string" },
       {
         "components": [
-          {
-            "internalType": "enum ComponentType",
-            "name": "componentType",
-            "type": "uint8"
-          },
-          {
-            "internalType": "uint256",
-            "name": "itemIdOrOtomTokenId",
-            "type": "uint256"
-          },
+          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
           { "internalType": "uint256", "name": "amount", "type": "uint256" },
           {
             "components": [
-              {
-                "internalType": "enum PropertyType",
-                "name": "propertyType",
-                "type": "uint8"
-              },
-              {
-                "internalType": "uint256",
-                "name": "minValue",
-                "type": "uint256"
-              },
-              {
-                "internalType": "uint256",
-                "name": "maxValue",
-                "type": "uint256"
-              },
+              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
               { "internalType": "bool", "name": "boolValue", "type": "bool" },
-              {
-                "internalType": "bool",
-                "name": "checkBoolValue",
-                "type": "bool"
-              },
-              {
-                "internalType": "string",
-                "name": "stringValue",
-                "type": "string"
-              },
-              {
-                "internalType": "bool",
-                "name": "checkStringValue",
-                "type": "bool"
-              },
-              {
-                "internalType": "bytes32",
-                "name": "bytes32Value",
-                "type": "bytes32"
-              },
-              {
-                "internalType": "bool",
-                "name": "checkBytes32Value",
-                "type": "bool"
-              }
+              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+              { "internalType": "string", "name": "stringValue", "type": "string" },
+              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
             ],
             "internalType": "struct PropertyCriterion[]",
             "name": "criteria",
@@ -1302,16 +740,8 @@
         "components": [
           { "internalType": "string", "name": "typeName", "type": "string" },
           { "internalType": "string", "name": "valueString", "type": "string" },
-          {
-            "internalType": "uint256",
-            "name": "valueNumber",
-            "type": "uint256"
-          },
-          {
-            "internalType": "enum TraitType",
-            "name": "traitType",
-            "type": "uint8"
-          }
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
         ],
         "internalType": "struct Trait[]",
         "name": "_traits",
@@ -1319,11 +749,7 @@
       },
       { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
       { "internalType": "address", "name": "_feeRecipient", "type": "address" },
-      {
-        "internalType": "uint256",
-        "name": "_defaultCraftAmount",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "_defaultCraftAmount", "type": "uint256" }
     ],
     "name": "updateFungibleItem",
     "outputs": [],
@@ -1335,72 +761,24 @@
       { "internalType": "uint256", "name": "_itemId", "type": "uint256" },
       { "internalType": "string", "name": "_name", "type": "string" },
       { "internalType": "string", "name": "_description", "type": "string" },
-      {
-        "internalType": "string",
-        "name": "_defaultImageUri",
-        "type": "string"
-      },
-      {
-        "internalType": "string[7]",
-        "name": "_defaultTierImageUris",
-        "type": "string[7]"
-      },
+      { "internalType": "string", "name": "_defaultImageUri", "type": "string" },
+      { "internalType": "string[7]", "name": "_defaultTierImageUris", "type": "string[7]" },
       {
         "components": [
-          {
-            "internalType": "enum ComponentType",
-            "name": "componentType",
-            "type": "uint8"
-          },
-          {
-            "internalType": "uint256",
-            "name": "itemIdOrOtomTokenId",
-            "type": "uint256"
-          },
+          { "internalType": "enum ComponentType", "name": "componentType", "type": "uint8" },
+          { "internalType": "uint256", "name": "itemIdOrOtomTokenId", "type": "uint256" },
           { "internalType": "uint256", "name": "amount", "type": "uint256" },
           {
             "components": [
-              {
-                "internalType": "enum PropertyType",
-                "name": "propertyType",
-                "type": "uint8"
-              },
-              {
-                "internalType": "uint256",
-                "name": "minValue",
-                "type": "uint256"
-              },
-              {
-                "internalType": "uint256",
-                "name": "maxValue",
-                "type": "uint256"
-              },
+              { "internalType": "enum PropertyType", "name": "propertyType", "type": "uint8" },
+              { "internalType": "uint256", "name": "minValue", "type": "uint256" },
+              { "internalType": "uint256", "name": "maxValue", "type": "uint256" },
               { "internalType": "bool", "name": "boolValue", "type": "bool" },
-              {
-                "internalType": "bool",
-                "name": "checkBoolValue",
-                "type": "bool"
-              },
-              {
-                "internalType": "string",
-                "name": "stringValue",
-                "type": "string"
-              },
-              {
-                "internalType": "bool",
-                "name": "checkStringValue",
-                "type": "bool"
-              },
-              {
-                "internalType": "bytes32",
-                "name": "bytes32Value",
-                "type": "bytes32"
-              },
-              {
-                "internalType": "bool",
-                "name": "checkBytes32Value",
-                "type": "bool"
-              }
+              { "internalType": "bool", "name": "checkBoolValue", "type": "bool" },
+              { "internalType": "string", "name": "stringValue", "type": "string" },
+              { "internalType": "bool", "name": "checkStringValue", "type": "bool" },
+              { "internalType": "bytes32", "name": "bytes32Value", "type": "bytes32" },
+              { "internalType": "bool", "name": "checkBytes32Value", "type": "bool" }
             ],
             "internalType": "struct PropertyCriterion[]",
             "name": "criteria",
@@ -1415,26 +793,14 @@
         "components": [
           { "internalType": "string", "name": "typeName", "type": "string" },
           { "internalType": "string", "name": "valueString", "type": "string" },
-          {
-            "internalType": "uint256",
-            "name": "valueNumber",
-            "type": "uint256"
-          },
-          {
-            "internalType": "enum TraitType",
-            "name": "traitType",
-            "type": "uint8"
-          }
+          { "internalType": "uint256", "name": "valueNumber", "type": "uint256" },
+          { "internalType": "enum TraitType", "name": "traitType", "type": "uint8" }
         ],
         "internalType": "struct Trait[]",
         "name": "_traits",
         "type": "tuple[]"
       },
-      {
-        "internalType": "address",
-        "name": "_mutatorContract",
-        "type": "address"
-      },
+      { "internalType": "address", "name": "_mutatorContract", "type": "address" },
       { "internalType": "uint256", "name": "_ethCostInWei", "type": "uint256" },
       { "internalType": "address", "name": "_feeRecipient", "type": "address" }
     ],


### PR DESCRIPTION
allows mutators to handle the `defaultImageUri` field in item metadata